### PR TITLE
Adds clipboard comparison support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Features
 
-You can compare (diff) two text selections within a file or across different files.
+You can compare (diff) text selections within a file, across different files, or to the clipboard.
 
 ![Compare two text selections](https://raw.githubusercontent.com/ryu1kn/vscode-partial-diff/master/images/select-2-texts-and-take-diff.gif)
 
@@ -12,11 +12,13 @@ You can compare (diff) two text selections within a file or across different fil
 
 * `Select Text for Compare`: Marks the selected text as the text to compare the next selection with.
 * `Compare Text with Previous Selection`: Compares the selected text to the first selection.
+* `Compare Text with Clipboard`: Compares the current clipboard to the selected text.
 
 **NOTE:**
 
 * A diff will be shown only after selecting comparison text first (using `Select Text for Compare`)
 * Executing the `Select Text for Compare` or `Compare Text with Previous Selection` command without selecting any text will use the entire text of the current file
+* If the `Compare Text with Clipboard` command doesn't work on Linux -- `xclip` needs to be installed. You can install it via `sudo apt-get install xclip`
 
 ## Keyboard Shortcuts
 
@@ -26,6 +28,8 @@ You can quickly mark the selected text by adding the `partial-diff` commands to 
   { "key": "ctrl+1", "command": "extension.partialDiff.markSection1",
                         "when": "editorTextFocus" },
   { "key": "ctrl+2", "command": "extension.partialDiff.markSection2AndTakeDiff",
+                        "when": "editorTextFocus" }
+  { "key": "ctrl+3", "command": "extension.partialDiff.diffSelectionWithClipboard",
                         "when": "editorTextFocus" }
 ```
 

--- a/lib/app-factory.js
+++ b/lib/app-factory.js
@@ -3,6 +3,7 @@ const App = require('./app');
 const DiffPresenter = require('./diff-presenter');
 const EditorTextExtractor = require('./editor-text-extractor');
 const path = require('path');
+const copyPaste = require('copy-paste');
 
 class AppFactory {
 
@@ -21,7 +22,8 @@ class AppFactory {
             diffPresenter: this._createDiffPresenter(),
             logger: this._logger,
             vscode: this._vscode,
-            path
+            path,
+            copyPaste
         });
     }
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -1,4 +1,3 @@
-
 class App {
 
     constructor(params) {
@@ -9,15 +8,38 @@ class App {
         this._textResourceUtil = params.textResourceUtil;
         this._vscode = params.vscode;
         this._path = params.path;
+        this._copyPaste = params.copyPaste;
+    }
+
+    diffSelectionWithClipboard(editor) {
+        return new Promise((resolve, reject) => {
+            this._copyPaste.paste((err, text) => {
+                if (err) return reject(err);
+                if (!text) return resolve();
+
+                this._textRegistry.set('1', text, 'Clipboard', null);
+                this._setContext();
+                resolve();
+            });
+
+            // Cancel the promise if it doesn't succeed after a short (1.5s) timeout
+            setTimeout(() => reject(new Error('Clipboard timed out')), 1500);
+        })
+            .then(() => this.saveSelectionAsText2AndTakeDiff(editor))
+            .catch(this._handleError.bind(this));
     }
 
     saveSelectionAsText1(editor) {
         try {
             this._saveSelectionAsText('1', editor);
-            this._vscode.commands.executeCommand('setContext', 'partialDiff:hasSelectedText', true);
+            this._setContext();
         } catch (e) {
             this._handleError(e);
         }
+    }
+
+    _setContext() {
+        return this._vscode.commands.executeCommand('setContext', 'partialDiff:hasSelectedText', true);
     }
 
     _saveSelectionAsText(textKey, editor) {

--- a/lib/bootstrapper.js
+++ b/lib/bootstrapper.js
@@ -1,4 +1,3 @@
-
 const EXTENSION_NAMESPACE = 'extension.partialDiff';
 
 class Bootstrapper {
@@ -25,7 +24,8 @@ class Bootstrapper {
         const app = this._app;
         const commandMap = new Map([
             [`${EXTENSION_NAMESPACE}.markSection1`, app.saveSelectionAsText1.bind(app)],
-            [`${EXTENSION_NAMESPACE}.markSection2AndTakeDiff`, app.saveSelectionAsText2AndTakeDiff.bind(app)]
+            [`${EXTENSION_NAMESPACE}.markSection2AndTakeDiff`, app.saveSelectionAsText2AndTakeDiff.bind(app)],
+            [`${EXTENSION_NAMESPACE}.diffSelectionWithClipboard`, app.diffSelectionWithClipboard.bind(app)]
         ]);
         commandMap.forEach((command, commandName) => {
             const disposable = this._vscode.commands.registerTextEditorCommand(commandName, command);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "partial-diff",
   "displayName": "Partial Diff",
-  "description": "Compare (diff) two text selections within a file or across files",
+  "description": "Compare (diff) text selections within a file, across files, or to the clipboard",
   "version": "0.3.0",
   "publisher": "ryu1kn",
   "license": "SEE LICENSE IN LICENSE.txt",
@@ -26,7 +26,8 @@
   ],
   "activationEvents": [
     "onCommand:extension.partialDiff.markSection1",
-    "onCommand:extension.partialDiff.markSection2AndTakeDiff"
+    "onCommand:extension.partialDiff.markSection2AndTakeDiff",
+    "onCommand:extension.partialDiff.diffSelectionWithClipboard"
   ],
   "main": "./extension",
   "contributes": {
@@ -40,6 +41,11 @@
         "command": "extension.partialDiff.markSection2AndTakeDiff",
         "title": "Compare Text with Previous Selection",
         "category": "PartialDiff"
+      },
+      {
+        "command": "extension.partialDiff.diffSelectionWithClipboard",
+        "title": "Compare Text with Clipboard",
+        "category": "PartialDiff"
       }
     ],
     "menus": {
@@ -50,18 +56,26 @@
         {
           "command": "extension.partialDiff.markSection2AndTakeDiff",
           "when": "partialDiff:hasSelectedText"
+        },
+        {
+          "command": "extension.partialDiff.diffSelectionWithClipboard"
         }
       ],
       "editor/context": [
         {
+          "command": "extension.partialDiff.markSection2AndTakeDiff",
+          "group": "2_partialdiff@1",
+          "when": "editorTextFocus && partialDiff:hasSelectedText"
+        },
+        {
           "command": "extension.partialDiff.markSection1",
-          "group": "2_partialdiff",
+          "group": "2_partialdiff@2",
           "when": "editorTextFocus"
         },
         {
-          "command": "extension.partialDiff.markSection2AndTakeDiff",
-          "group": "2_partialdiff",
-          "when": "editorTextFocus && partialDiff:hasSelectedText"
+          "command": "extension.partialDiff.diffSelectionWithClipboard",
+          "group": "2_partialdiff@3",
+          "when": "editorTextFocus"
         }
       ]
     }
@@ -72,6 +86,9 @@
     "postinstall": "node ./node_modules/vscode/bin/install",
     "test": "mocha --opts cli-test-mocha.opts",
     "test-mode": "mocha --opts cli-test-mocha.opts --watch"
+  },
+  "dependencies": {
+      "copy-paste": "1.3.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/test/lib/bootstrapper.test.js
+++ b/test/lib/bootstrapper.test.js
@@ -6,7 +6,8 @@ suite('Bootstrapper', () => {
     test('it registers commands', () => {
         const app = {
             saveSelectionAsText1: () => 'saveSelectionAsText1 called',
-            saveSelectionAsText2AndTakeDiff: () => 'saveSelectionAsText2AndTakeDiff called'
+            saveSelectionAsText2AndTakeDiff: () => 'saveSelectionAsText2AndTakeDiff called',
+            diffSelectionWithClipboard: () => 'diffSelectionWithClipboard called'
         };
         const commands = fakeVSCodeCommands();
         const extensionScheme = 'EXTENSION_SCHEME';
@@ -26,7 +27,8 @@ suite('Bootstrapper', () => {
         expect(context.subscriptions).to.eql([
             'DISPOSABLE_scheme',
             'DISPOSABLE_extension.partialDiff.markSection1',
-            'DISPOSABLE_extension.partialDiff.markSection2AndTakeDiff'
+            'DISPOSABLE_extension.partialDiff.markSection2AndTakeDiff',
+            'DISPOSABLE_extension.partialDiff.diffSelectionWithClipboard'
         ]);
     });
 


### PR DESCRIPTION
Adds a new `extension.partialDiff.diffSelectionWithClipboard` command that compares the clipboard to the selected text.

Since this builds on https://github.com/ryu1kn/vscode-partial-diff/pull/5 -- the diff here isn't as nice as it should be. The changes specific for this PR are in https://github.com/eamodio/vscode-partial-diff/commit/711856f74c1bed8da69f3b101f3c18cf5a94de4e