### PR TITLE
Update activationEvents to delay extension startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "telemetryKey": "99489808-a33c-4235-af6d-04f95a652ead",
   "activationEvents": [
-    "*"
+    "onStartupFinished"
   ],
   "main": "./out/extension",
   "contributes": {


### PR DESCRIPTION
Change `"*"` to `"onStartupFinished"` in `package.json` to ensure extension does not affect application launch times unnecessarily