### PR TITLE
Preserve file names for language detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "partial-diff",
   "displayName": "Partial Diff",
   "description": "Compare (diff) text selections within a file, across files, or to the clipboard",
-  "version": "1.4.2",
+  "version": "1.4.4",
   "publisher": "ryu1kn",
   "license": "SEE LICENSE IN LICENSE.txt",
   "icon": "images/partial-diff_128x128.png",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "partial-diff",
   "displayName": "Partial Diff",
   "description": "Compare (diff) text selections within a file, across files, or to the clipboard",
-  "version": "1.4.3",
+  "version": "1.4.2",
   "publisher": "ryu1kn",
   "license": "SEE LICENSE IN LICENSE.txt",
   "icon": "images/partial-diff_128x128.png",

--- a/src/lib/diff-presenter.ts
+++ b/src/lib/diff-presenter.ts
@@ -7,7 +7,7 @@ import DiffTitleBuilder from './diff-title-builder';
 export default class DiffPresenter {
     private readonly diffTitleBuilder: DiffTitleBuilder;
 
-    constructor(selectionInfoRegistry: SelectionInfoRegistry,
+    constructor(private readonly selectionInfoRegistry: SelectionInfoRegistry,
                 normalisationRuleStore: NormalisationRuleStore,
                 private readonly commandAdaptor: CommandAdaptor,
                 private readonly getCurrentDate: () => Date) {
@@ -17,7 +17,8 @@ export default class DiffPresenter {
     }
 
     takeDiff(textKey1: string, textKey2: string): Promise<{} | undefined> {
-        const getUri = (textKey: string) => makeUriString(textKey, this.getCurrentDate());
+        const getFileName = (textKey: string) => this.selectionInfoRegistry.get(textKey).fileName;
+        const getUri = (textKey: string) => makeUriString(textKey, getFileName(textKey), this.getCurrentDate());
         const title = this.diffTitleBuilder.build(textKey1, textKey2);
         return this.commandAdaptor.executeCommand('vscode.diff', getUri(textKey1), getUri(textKey2), title);
     }

--- a/src/lib/utils/text-resource.ts
+++ b/src/lib/utils/text-resource.ts
@@ -1,8 +1,9 @@
+import {URLSearchParams} from 'url';
 import * as vscode from 'vscode';
 import {EXTENSION_SCHEME} from '../const';
 
-export const makeUriString = (textKey: string, timestamp: Date): string =>
-    `${EXTENSION_SCHEME}:text/${textKey}?_ts=${timestamp.getTime()}`; // `_ts` to avoid cache
+export const makeUriString = (textKey: string, fileName: string, timestamp: Date): string =>
+    `${EXTENSION_SCHEME}:text/${fileName}?key=${textKey}&_ts=${timestamp.getTime()}`; // `_ts` to avoid cache
 
 export const extractTextKey = (uri: vscode.Uri): string =>
-    uri.path.match(/^text\/([a-z\d]+)/)![1];
+    new URLSearchParams(uri.query).get('key')!;

--- a/src/test/lib/commands/compare-selection-with-clipboard.test.ts
+++ b/src/test/lib/commands/compare-selection-with-clipboard.test.ts
@@ -42,8 +42,8 @@ suite('CompareSelectionWithClipboardCommand', () => {
         });
         verify(commandAdaptor.executeCommand(
             'vscode.diff',
-            'partialdiff:text/clipboard?_ts=1465990980000',
-            'partialdiff:text/reg2?_ts=1465990980000',
+            'partialdiff:text/Clipboard?key=clipboard&_ts=1465990980000',
+            'partialdiff:text/FILE2?key=reg2&_ts=1465990980000',
             'Clipboard ↔ FILE2 (ll.6-11)'
         ));
     });

--- a/src/test/lib/commands/compare-selection-with-text1.test.ts
+++ b/src/test/lib/commands/compare-selection-with-text1.test.ts
@@ -42,8 +42,8 @@ suite('CompareSelectionWithText1', () => {
         });
         verify(commandAdaptor.executeCommand(
             'vscode.diff',
-            'partialdiff:text/reg1?_ts=1465990980000',
-            'partialdiff:text/reg2?_ts=1465990980000',
+            'partialdiff:text/FILE1?key=reg1&_ts=1465990980000',
+            'partialdiff:text/FILE2?key=reg2&_ts=1465990980000',
             'FILE1 (ll.21-26) ↔ FILE2 (ll.6-11)'
         ));
     });

--- a/src/test/lib/commands/compare-visible-editors.test.ts
+++ b/src/test/lib/commands/compare-visible-editors.test.ts
@@ -38,8 +38,8 @@ suite('CompareVisibleEditorsCommand', () => {
         });
         verify(deps.commandAdaptor.executeCommand(
             'vscode.diff',
-            'partialdiff:text/visible1?_ts=1465990980000',
-            'partialdiff:text/visible2?_ts=1465990980000',
+            'partialdiff:text/FILE1?key=visible1&_ts=1465990980000',
+            'partialdiff:text/FILE2?key=visible2&_ts=1465990980000',
             'FILE1 (ll.6-11) ↔ FILE2 (ll.16-21)'
         ));
     });

--- a/src/test/lib/content-provider.test.ts
+++ b/src/test/lib/content-provider.test.ts
@@ -21,12 +21,12 @@ suite('ContentProvider', () => {
         const contentProvider = new ContentProvider(selectionInfoRegistry, normalisationRuleStore);
 
         test('it extracts text key from the given uri and uses it to retrieve text', () => {
-            const uri = mockType<vscode.Uri>({path: 'text/key1'});
+            const uri = mockType<vscode.Uri>({path: 'text/file.txt', query: 'key=key1'});
             assert.deepEqual(contentProvider.provideTextDocumentContent(uri), 'TEXT:1');
         });
 
         test('it returns an empty string if a text is not yet selected', () => {
-            const uri = mockType<vscode.Uri>({path: 'text/keyNotExist'});
+            const uri = mockType<vscode.Uri>({path: 'text/file.txt', query: 'key=keyNotExist'});
             assert.deepEqual(contentProvider.provideTextDocumentContent(uri), '');
         });
     });
@@ -36,7 +36,7 @@ suite('ContentProvider', () => {
         const contentProvider = new ContentProvider(selectionInfoRegistry, normalisationRuleStore);
 
         test('it returns the registered text as is', () => {
-            const uri = mockType<vscode.Uri>({path: 'text/key1'});
+            const uri = mockType<vscode.Uri>({path: 'text/file.txt', query: 'key=key1'});
             assert.deepEqual(contentProvider.provideTextDocumentContent(uri), 'TEXT_1');
         });
     });

--- a/src/test/lib/diff-presenter.test.ts
+++ b/src/test/lib/diff-presenter.test.ts
@@ -23,8 +23,8 @@ suite('DiffPresenter', () => {
 
         verify(commandAdaptor.executeCommand(
             'vscode.diff',
-            'partialdiff:text/TEXT1?_ts=1465990980000',
-            'partialdiff:text/TEXT2?_ts=1465990980000',
+            'partialdiff:text/FILE1?key=TEXT1&_ts=1465990980000',
+            'partialdiff:text/FILE2?key=TEXT2&_ts=1465990980000',
             'FILE1 \u2194 FILE2'
         ));
     });

--- a/src/test/lib/text-resource-util.test.ts
+++ b/src/test/lib/text-resource-util.test.ts
@@ -1,19 +1,19 @@
 import {extractTextKey, makeUriString} from '../../lib/utils/text-resource';
 import * as assert from 'assert';
-import {Uri} from 'vscode';
+import type {Uri} from 'vscode';
 
 suite('Text Resource Utilities', () => {
     const date = new Date('2016-06-15T11:43:00Z');
 
     suite('#makeUriString', () => {
         test('it converts a given text key into an uri', () => {
-            assert.deepEqual(makeUriString('reg1', date), 'partialdiff:text/reg1?_ts=1465990980000');
+            assert.deepEqual(makeUriString('reg1', 'file.txt', date), 'partialdiff:text/file.txt?key=reg1&_ts=1465990980000');
         });
     });
 
     suite('#extractTextKey', () => {
         test('it extracts a text key information from the given uri', () => {
-            const uri = {path: 'text/reg1'};
+            const uri = {path: 'text/file.txt', query: 'key=reg1'};
             assert.deepEqual(extractTextKey(uri as Uri), 'reg1');
         });
     });


### PR DESCRIPTION
VSCode is able to detect and apply language modes automatically, looking at (among other things) file extensions. This PR makes it so the ContentProvider URIs preserve extensions of their source files. That enables VSCode to set language modes by default.