### PR TITLE
Add editable diffs that apply edits back to source documents

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,5 +1,5 @@
 {
   "ui": "tdd",
-  "require": ["ts-node/register"],
+  "require": ["./src/test/register-vscode-mock.js", "ts-node/register"],
   "spec": "src/test/**/*.ts"
 }

--- a/package.json
+++ b/package.json
@@ -117,6 +117,11 @@
           "description": "Enable usage data to be sent to the extension authour",
           "type": "boolean",
           "default": true
+        },
+        "partialDiff.enableEditableDiffs": {
+          "description": "Open diffs in editable mode. Edits made in the diff view are applied back to the source document",
+          "type": "boolean",
+          "default": true
         }
       }
     },

--- a/src/lib/adaptors/command.ts
+++ b/src/lib/adaptors/command.ts
@@ -13,6 +13,11 @@ export interface CommandItem {
     command: Command;
 }
 
+export interface EditableDiffOptions {
+    originalEditable?: boolean;
+    preferredGroup?: 'up' | 'down' | 'left' | 'right';
+}
+
 export default class CommandAdaptor {
     constructor(private readonly commands: typeof vscode.commands,
                 private readonly parseUri: UriParser,
@@ -20,6 +25,38 @@ export default class CommandAdaptor {
 
     async executeCommand(name: string, uri1: string, uri2: string, title: string): Promise<{} | undefined> {
         return this.commands.executeCommand(name, this.parseUri(uri1), this.parseUri(uri2), title);
+    }
+
+    async executeDiffUris(uri1: vscode.Uri,
+                          uri2: vscode.Uri,
+                          title: string,
+                          options?: EditableDiffOptions): Promise<{} | undefined> {
+        const originalEditable = options && options.originalEditable !== undefined ? options.originalEditable : true;
+        const preferredGroup = options && options.preferredGroup ? options.preferredGroup : 'up';
+        const diffEditorOptions = {
+            originalEditable,
+            renderSideBySide: true,
+            useInlineViewWhenSpaceIsLimited: false
+        };
+        // Use internal workbench command to pass diff-editor options for editable sessions.
+        try {
+            return await this.commands.executeCommand(
+                '_workbench.diff',
+                uri1,
+                uri2,
+                title,
+                [preferredGroup, diffEditorOptions]
+            );
+        } catch (error) {
+            // Fallback for hosts that don't accept directional preferred-group hints.
+            return this.commands.executeCommand(
+                '_workbench.diff',
+                uri1,
+                uri2,
+                title,
+                [undefined, diffEditorOptions]
+            );
+        }
     }
 
     registerCommand(cmd: CommandItem): vscode.Disposable {

--- a/src/lib/adaptors/text-editor.ts
+++ b/src/lib/adaptors/text-editor.ts
@@ -1,12 +1,30 @@
 import {Selection, TextEditor as VsTextEditor, ViewColumn} from 'vscode';
 import {basename} from 'path';
-import {LineRange} from '../types/selection-info';
+import {LineRange, SelectionRange} from '../types/selection-info';
 
 export default class TextEditor {
     constructor(private readonly vsEditor: VsTextEditor) {}
 
     get fileName(): string {
         return basename(this.vsEditor.document.fileName);
+    }
+
+    get uri(): string {
+        return this.vsEditor.document.uri.toString();
+    }
+
+    get singleSelectionRange(): SelectionRange | undefined {
+        const validSelections = this.collectNonEmptySelections(this.vsEditor.selections);
+        if (validSelections.length !== 1) {
+            return undefined;
+        }
+        const selection = validSelections[0];
+        return {
+            startLine: selection.start.line,
+            startChar: selection.start.character,
+            endLine: selection.end.line,
+            endChar: selection.end.character
+        };
     }
 
     get viewColumn(): ViewColumn {
@@ -23,7 +41,7 @@ export default class TextEditor {
         return this.extractLineRanges(validSelections);
     }
 
-    private collectNonEmptySelections(selections: Selection[]): Selection[] {
+    private collectNonEmptySelections(selections: readonly Selection[]): Selection[] {
         return selections.filter(s => !s.isEmpty).sort((s1, s2) => {
             const lineComparison = s1.start.line - s2.start.line;
             return lineComparison !== 0

--- a/src/lib/adaptors/window.ts
+++ b/src/lib/adaptors/window.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import TextEditor from './text-editor';
 import {QuickPickItem, TextEditor as VsTextEditor} from 'vscode';
+import {SelectionRange} from '../types/selection-info';
 
 export default class WindowAdaptor {
     constructor(private readonly window: typeof vscode.window) {}
@@ -16,5 +17,22 @@ export default class WindowAdaptor {
 
     async showInformationMessage(message: string): Promise<string | undefined> {
         return this.window.showInformationMessage(message);
+    }
+
+    async showWarningMessage(message: string, ...actions: string[]): Promise<string | undefined> {
+        return this.window.showWarningMessage(message, ...actions);
+    }
+
+    setSelectionInVisibleEditor(uri: vscode.Uri, selectionRange: SelectionRange): void {
+        const editor = this.window.visibleTextEditors
+            .find(visibleEditor => visibleEditor.document.uri.toString() === uri.toString());
+        if (!editor) {
+            return;
+        }
+        const selection = new vscode.Selection(
+            new vscode.Position(selectionRange.startLine, selectionRange.startChar),
+            new vscode.Position(selectionRange.endLine, selectionRange.endChar)
+        );
+        editor.selections = [selection];
     }
 }

--- a/src/lib/adaptors/workspace.ts
+++ b/src/lib/adaptors/workspace.ts
@@ -13,4 +13,34 @@ export default class WorkspaceAdaptor {
     registerTextDocumentContentProvider(EXTENSION_SCHEME: string, contentProvider: ContentProvider): vscode.Disposable {
         return this.workspace.registerTextDocumentContentProvider(EXTENSION_SCHEME, contentProvider);
     }
+
+    registerFileSystemProvider(scheme: string,
+                               provider: vscode.FileSystemProvider,
+                               options?: {isCaseSensitive?: boolean; isReadonly?: boolean}): vscode.Disposable {
+        return this.workspace.registerFileSystemProvider(scheme, provider, options);
+    }
+
+    openTextDocument(uri: vscode.Uri): Thenable<vscode.TextDocument> {
+        return this.workspace.openTextDocument(uri);
+    }
+
+    onDidChangeTextDocument(listener: (event: vscode.TextDocumentChangeEvent) => void): vscode.Disposable {
+        return this.workspace.onDidChangeTextDocument(listener);
+    }
+
+    onDidCloseTextDocument(listener: (document: vscode.TextDocument) => void): vscode.Disposable {
+        return this.workspace.onDidCloseTextDocument(listener);
+    }
+
+    applyEdit(edit: vscode.WorkspaceEdit): Thenable<boolean> {
+        return this.workspace.applyEdit(edit);
+    }
+
+    writeFile(uri: vscode.Uri, content: Uint8Array): Thenable<void> {
+        return this.workspace.fs.writeFile(uri, content);
+    }
+
+    deleteFile(uri: vscode.Uri): Thenable<void> {
+        return this.workspace.fs.delete(uri);
+    }
 }

--- a/src/lib/apply-back-service.ts
+++ b/src/lib/apply-back-service.ts
@@ -1,0 +1,205 @@
+import * as vscode from 'vscode';
+import WorkspaceAdaptor from './adaptors/workspace';
+import WindowAdaptor from './adaptors/window';
+import {DiffSession, DiffSessionSide} from './types/diff-session';
+import {SelectionRange} from './types/selection-info';
+
+/**
+ * Applies edits made in an editable diff session back to the source
+ * document the text was taken from. Writes are debounced so that
+ * intermediate states while typing do not trigger a write per keystroke.
+ */
+export default class ApplyBackService {
+    private readonly timers = new Map<string, ReturnType<typeof setTimeout>>();
+
+    constructor(private readonly workspaceAdaptor: WorkspaceAdaptor,
+                private readonly windowAdaptor: WindowAdaptor,
+                private readonly debounceMs: number) {}
+
+    scheduleApply(session: DiffSession, side: DiffSessionSide): void {
+        this.schedule(this.sessionKey(session, side), () => this.applySide(side),
+            'Failed to apply editable diff changes back to source document.');
+    }
+
+    scheduleRefresh(session: DiffSession, side: DiffSessionSide): void {
+        this.schedule(`${this.sessionKey(session, side)}:refresh`, () => this.refreshSide(side),
+            'Failed to refresh editable diff from source document.');
+    }
+
+    cancelSession(session: DiffSession): void {
+        [session.left, session.right].forEach(side => {
+            const baseKey = this.sessionKey(session, side);
+            [baseKey, `${baseKey}:refresh`].forEach(key => {
+                const timer = this.timers.get(key);
+                if (timer) {
+                    clearTimeout(timer);
+                    this.timers.delete(key);
+                }
+            });
+        });
+    }
+
+    private schedule(key: string, task: () => Promise<void>, errorMessage: string): void {
+        const existingTimer = this.timers.get(key);
+        if (existingTimer) {
+            clearTimeout(existingTimer);
+        }
+
+        const timer = setTimeout(() => {
+            this.timers.delete(key);
+            void task().catch(error => {
+                console.error(errorMessage, error);
+            });
+        }, this.debounceMs);
+        this.timers.set(key, timer);
+    }
+
+    private sessionKey(session: DiffSession, side: DiffSessionSide): string {
+        return `${session.id}:${side.textKey}`;
+    }
+
+    private async applySide(side: DiffSessionSide, force = false): Promise<void> {
+        const info = side.selectionInfo;
+        if (info.targetKind === 'clipboard' || !info.sourceUri) {
+            return;
+        }
+
+        const tempDoc = await this.workspaceAdaptor.openTextDocument(side.tempUri);
+        const nextText = tempDoc.getText();
+        const sourceDoc = await this.workspaceAdaptor.openTextDocument(vscode.Uri.parse(info.sourceUri));
+        const {range, text: currentTargetText} = this.getTargetRangeAndText(sourceDoc, info);
+
+        if (nextText === currentTargetText) {
+            // Already in sync (e.g. this write was triggered by a source-to-diff refresh).
+            side.originalText = nextText;
+            side.conflictNotified = false;
+            return;
+        }
+
+        if (!force && currentTargetText !== side.originalText) {
+            if (!side.conflictNotified) {
+                side.conflictNotified = true;
+                const choice = await this.windowAdaptor.showWarningMessage(
+                    'Apply-back blocked: source changed since diff opened.',
+                    'Force Apply'
+                );
+                if (choice === 'Force Apply') {
+                    return this.applySide(side, true);
+                }
+            }
+            return;
+        }
+
+        const edit = new vscode.WorkspaceEdit();
+        edit.replace(sourceDoc.uri, range, nextText);
+        const applied = await this.workspaceAdaptor.applyEdit(edit);
+        if (applied) {
+            side.originalText = nextText;
+            side.conflictNotified = false;
+            const selectionRange = this.updateSelectionRange(side, range, nextText, sourceDoc);
+            if (selectionRange) {
+                this.windowAdaptor.setSelectionInVisibleEditor(sourceDoc.uri, selectionRange);
+            }
+        }
+    }
+
+    private async refreshSide(side: DiffSessionSide): Promise<void> {
+        const info = side.selectionInfo;
+        if (info.targetKind === 'clipboard' || !info.sourceUri) {
+            return;
+        }
+
+        const sourceDoc = await this.workspaceAdaptor.openTextDocument(vscode.Uri.parse(info.sourceUri));
+        const tempDoc = await this.workspaceAdaptor.openTextDocument(side.tempUri);
+        const tempText = tempDoc.getText();
+        const {text: targetText} = this.getTargetRangeAndText(sourceDoc, info);
+
+        if (targetText === side.originalText) {
+            return; // Target region unchanged by this source edit.
+        }
+        if (targetText === tempText) {
+            // Already in sync (e.g. triggered by our own apply-back write).
+            side.originalText = targetText;
+            return;
+        }
+        if (tempText !== side.originalText) {
+            // The user has edits in the diff view; never clobber them.
+            // The apply-back conflict prompt covers this case.
+            return;
+        }
+
+        if (info.targetKind === 'selection') {
+            if (this.tryReanchorSelection(sourceDoc, side)) {
+                return; // Selected text only moved; range re-anchored, diff content unchanged.
+            }
+            if (!side.sourceChangeNotified) {
+                side.sourceChangeNotified = true;
+                await this.windowAdaptor.showWarningMessage(
+                    'Source text changed since diff opened. Close and re-run the compare to refresh the diff.'
+                );
+            }
+            return;
+        }
+
+        // Whole-document target: safe to push the new source text into the diff view.
+        await this.workspaceAdaptor.writeFile(side.tempUri, Buffer.from(targetText, 'utf8'));
+        side.originalText = targetText;
+        side.conflictNotified = false;
+        side.sourceChangeNotified = false;
+    }
+
+    private tryReanchorSelection(doc: vscode.TextDocument, side: DiffSessionSide): boolean {
+        const info = side.selectionInfo;
+        if (!info.selectionRange || side.originalText.length === 0) {
+            return false;
+        }
+        const fullText = doc.getText();
+        const firstIndex = fullText.indexOf(side.originalText);
+        if (firstIndex === -1 || fullText.indexOf(side.originalText, firstIndex + 1) !== -1) {
+            return false; // Not found or ambiguous.
+        }
+        const start = doc.positionAt(firstIndex);
+        const end = doc.positionAt(firstIndex + side.originalText.length);
+        info.selectionRange = {
+            startLine: start.line,
+            startChar: start.character,
+            endLine: end.line,
+            endChar: end.character
+        };
+        return true;
+    }
+
+    private updateSelectionRange(side: DiffSessionSide,
+                                 replacedRange: vscode.Range,
+                                 newText: string,
+                                 doc: vscode.TextDocument): SelectionRange | undefined {
+        if (side.selectionInfo.targetKind !== 'selection' || !side.selectionInfo.selectionRange) {
+            return undefined;
+        }
+        const startOffset = doc.offsetAt(replacedRange.start);
+        const newEnd = doc.positionAt(startOffset + newText.length);
+        const selectionRange = {
+            startLine: replacedRange.start.line,
+            startChar: replacedRange.start.character,
+            endLine: newEnd.line,
+            endChar: newEnd.character
+        };
+        side.selectionInfo.selectionRange = selectionRange;
+        return selectionRange;
+    }
+
+    private getTargetRangeAndText(doc: vscode.TextDocument,
+                                  info: DiffSessionSide['selectionInfo']): {range: vscode.Range; text: string} {
+        if (info.targetKind === 'selection' && info.selectionRange) {
+            const range = new vscode.Range(
+                new vscode.Position(info.selectionRange.startLine, info.selectionRange.startChar),
+                new vscode.Position(info.selectionRange.endLine, info.selectionRange.endChar)
+            );
+            return {range, text: doc.getText(range)};
+        }
+        const text = doc.getText();
+        const end = doc.positionAt(text.length);
+        const range = new vscode.Range(new vscode.Position(0, 0), end);
+        return {range, text};
+    }
+}

--- a/src/lib/bootstrapper-factory.ts
+++ b/src/lib/bootstrapper-factory.ts
@@ -9,6 +9,9 @@ import CommandAdaptor from './adaptors/command';
 import WindowAdaptor from './adaptors/window';
 import {NullVsTelemetryReporter, VsTelemetryReporterCreator} from './telemetry-reporter';
 import VsTelemetryReporter from 'vscode-extension-telemetry';
+import EditableDiffSessionManager from './editable-diff-session-manager';
+import ApplyBackService from './apply-back-service';
+import EditableDiffFileSystemProvider from './editable-diff-file-system-provider';
 
 export default class BootstrapperFactory {
     private workspaceAdaptor?: WorkspaceAdaptor;
@@ -19,16 +22,34 @@ export default class BootstrapperFactory {
         const workspaceAdaptor = this.getWorkspaceAdaptor();
         const commandAdaptor = new CommandAdaptor(vscode.commands, vscode.Uri.parse, logger);
         const normalisationRuleStore = new NormalisationRuleStore(workspaceAdaptor);
+        const windowAdaptor = new WindowAdaptor(vscode.window);
+        const applyBackService = new ApplyBackService(workspaceAdaptor, windowAdaptor, 400);
+        const editableDiffSessionManager = new EditableDiffSessionManager(
+            selectionInfoRegistry,
+            workspaceAdaptor,
+            commandAdaptor,
+            applyBackService
+        );
+        const editableDiffFileSystemProvider = new EditableDiffFileSystemProvider();
         const commandFactory = new CommandFactory(
             selectionInfoRegistry,
             normalisationRuleStore,
+            workspaceAdaptor,
             commandAdaptor,
-            new WindowAdaptor(vscode.window),
+            windowAdaptor,
+            editableDiffSessionManager,
             vscode.env.clipboard,
             () => new Date()
         );
         const contentProvider = new ContentProvider(selectionInfoRegistry, normalisationRuleStore);
-        return new Bootstrapper(commandFactory, contentProvider, workspaceAdaptor, commandAdaptor);
+        return new Bootstrapper(
+            commandFactory,
+            contentProvider,
+            editableDiffFileSystemProvider,
+            workspaceAdaptor,
+            commandAdaptor,
+            editableDiffSessionManager
+        );
     }
 
     private getWorkspaceAdaptor() {

--- a/src/lib/bootstrapper.ts
+++ b/src/lib/bootstrapper.ts
@@ -1,27 +1,37 @@
 import CommandFactory from './command-factory';
 import ContentProvider from './content-provider';
-import {EXTENSION_NAMESPACE, EXTENSION_SCHEME} from './const';
+import {EDITABLE_DIFF_SCHEME, EXTENSION_NAMESPACE, EXTENSION_SCHEME} from './const';
 import {ExecutionContextLike} from './types/vscode';
 import WorkspaceAdaptor from './adaptors/workspace';
 import CommandAdaptor, {CommandItem} from './adaptors/command';
+import EditableDiffSessionManager from './editable-diff-session-manager';
+import EditableDiffFileSystemProvider from './editable-diff-file-system-provider';
 
 export default class Bootstrapper {
     constructor(private readonly commandFactory: CommandFactory,
                 private readonly contentProvider: ContentProvider,
+                private readonly editableDiffFileSystemProvider: EditableDiffFileSystemProvider,
                 private readonly workspaceAdaptor: WorkspaceAdaptor,
-                private readonly commandAdaptor: CommandAdaptor) {}
+                private readonly commandAdaptor: CommandAdaptor,
+                private readonly editableDiffSessionManager: EditableDiffSessionManager) {}
 
     initiate(context: ExecutionContextLike) {
         this.registerProviders(context);
         this.registerCommands(context);
+        context.subscriptions.push({dispose: () => this.editableDiffSessionManager.dispose()});
     }
 
     private registerProviders(context: ExecutionContextLike) {
-        const disposable = this.workspaceAdaptor.registerTextDocumentContentProvider(
+        const textProviderDisposable = this.workspaceAdaptor.registerTextDocumentContentProvider(
             EXTENSION_SCHEME,
             this.contentProvider
         );
-        context.subscriptions.push(disposable);
+        const editableFsDisposable = this.workspaceAdaptor.registerFileSystemProvider(
+            EDITABLE_DIFF_SCHEME,
+            this.editableDiffFileSystemProvider,
+            {isCaseSensitive: true}
+        );
+        context.subscriptions.push(textProviderDisposable, editableFsDisposable);
     }
 
     private registerCommands(context: ExecutionContextLike) {

--- a/src/lib/command-factory.ts
+++ b/src/lib/command-factory.ts
@@ -8,6 +8,8 @@ import NormalisationRuleStore from './normalisation-rule-store';
 import SelectionInfoRegistry from './selection-info-registry';
 import CommandAdaptor from './adaptors/command';
 import WindowAdaptor from './adaptors/window';
+import WorkspaceAdaptor from './adaptors/workspace';
+import EditableDiffSessionManager from './editable-diff-session-manager';
 import {Command} from './commands/command';
 import * as vscode from 'vscode';
 
@@ -16,8 +18,10 @@ export default class CommandFactory {
 
     constructor(private readonly selectionInfoRegistry: SelectionInfoRegistry,
                 private readonly normalisationRuleStore: NormalisationRuleStore,
+                private readonly workspaceAdaptor: WorkspaceAdaptor,
                 private readonly commandAdaptor: CommandAdaptor,
                 private readonly windowAdaptor: WindowAdaptor,
+                private readonly editableDiffSessionManager: EditableDiffSessionManager,
                 private readonly clipboard: typeof vscode.env.clipboard,
                 private readonly getCurrentDate: () => Date) {
     }
@@ -65,7 +69,10 @@ export default class CommandFactory {
         return new DiffPresenter(
             this.selectionInfoRegistry,
             this.normalisationRuleStore,
+            this.workspaceAdaptor,
             this.commandAdaptor,
+            this.windowAdaptor,
+            this.editableDiffSessionManager,
             this.getCurrentDate
         );
     }

--- a/src/lib/commands/compare-selection-with-clipboard.ts
+++ b/src/lib/commands/compare-selection-with-clipboard.ts
@@ -15,12 +15,16 @@ export default class CompareSelectionWithClipboardCommand implements Command {
         this.selectionInfoRegistry.set(TextKey.CLIPBOARD, {
             text,
             fileName: 'Clipboard',
-            lineRanges: []
+            lineRanges: [],
+            targetKind: 'clipboard'
         });
         this.selectionInfoRegistry.set(TextKey.REGISTER2, {
             text: editor.selectedText,
             fileName: editor.fileName,
-            lineRanges: editor.selectedLineRanges
+            lineRanges: editor.selectedLineRanges,
+            sourceUri: editor.uri,
+            targetKind: editor.selectedLineRanges.length === 0 ? 'document' : 'selection',
+            selectionRange: editor.singleSelectionRange
         });
 
         await this.diffPresenter.takeDiff(TextKey.CLIPBOARD, TextKey.REGISTER2);

--- a/src/lib/commands/compare-selection-with-text1.ts
+++ b/src/lib/commands/compare-selection-with-text1.ts
@@ -1,18 +1,22 @@
 import DiffPresenter from '../diff-presenter';
 import SelectionInfoRegistry from '../selection-info-registry';
 import {TextKey} from '../const';
+import {SelectionInfo} from '../types/selection-info';
 import {Command} from './command';
-import TextEditor from '../adaptors/text-editor';
+import TextEditor from '../adaptors/text-editor';       
 
 export default class CompareSelectionWithText1Command implements Command {
     constructor(private readonly diffPresenter: DiffPresenter,
                 private readonly selectionInfoRegistry: SelectionInfoRegistry) {}
 
     async execute(editor: TextEditor) {
-        const textInfo = {
+        const textInfo: SelectionInfo = {
             text: editor.selectedText,
             fileName: editor.fileName,
-            lineRanges: editor.selectedLineRanges
+            lineRanges: editor.selectedLineRanges,
+            sourceUri: editor.uri,
+            targetKind: editor.selectedLineRanges.length === 0 ? 'document' : 'selection',
+            selectionRange: editor.singleSelectionRange
         };
         this.selectionInfoRegistry.set(TextKey.REGISTER2, textInfo);
 

--- a/src/lib/commands/compare-visible-editors.ts
+++ b/src/lib/commands/compare-visible-editors.ts
@@ -22,7 +22,10 @@ export default class CompareVisibleEditorsCommand implements Command {
         const textInfos = editors.map(editor => ({
             text: editor.selectedText,
             fileName: editor.fileName,
-            lineRanges: editor.selectedLineRanges
+            lineRanges: editor.selectedLineRanges,
+            sourceUri: editor.uri,
+            targetKind: (editor.selectedLineRanges.length === 0 ? 'document' : 'selection') as 'document' | 'selection',
+            selectionRange: editor.singleSelectionRange
         }));
         this.registerTextInfo(
             textInfos,

--- a/src/lib/commands/save-text-1.ts
+++ b/src/lib/commands/save-text-1.ts
@@ -1,5 +1,6 @@
 import SelectionInfoRegistry from '../selection-info-registry';
 import {TextKey} from '../const';
+import {SelectionInfo} from '../types/selection-info';
 import {Command} from './command';
 import TextEditor from '../adaptors/text-editor';
 
@@ -7,10 +8,13 @@ export default class SaveText1Command implements Command {
     constructor(private readonly selectionInfoRegistry: SelectionInfoRegistry) {}
 
     execute(editor: TextEditor) {
-        const textInfo = {
+        const textInfo: SelectionInfo = {
             text: editor.selectedText,
             fileName: editor.fileName,
-            lineRanges: editor.selectedLineRanges
+            lineRanges: editor.selectedLineRanges,
+            sourceUri: editor.uri,
+            targetKind: editor.selectedLineRanges.length === 0 ? 'document' : 'selection',
+            selectionRange: editor.singleSelectionRange
         };
         this.selectionInfoRegistry.set(TextKey.REGISTER1, textInfo);
     }

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -4,6 +4,8 @@ export const EXTENSION_NAMESPACE = 'extension.partialDiff';
 
 export const EXTENSION_SCHEME = 'partialdiff';
 
+export const EDITABLE_DIFF_SCHEME = 'partialdiff-editable';
+
 export const TextKey = {
     REGISTER1: 'reg1',
     REGISTER2: 'reg2',

--- a/src/lib/diff-presenter.ts
+++ b/src/lib/diff-presenter.ts
@@ -3,20 +3,38 @@ import SelectionInfoRegistry from './selection-info-registry';
 import {makeUriString} from './utils/text-resource';
 import CommandAdaptor from './adaptors/command';
 import DiffTitleBuilder from './diff-title-builder';
+import WorkspaceAdaptor from './adaptors/workspace';
+import WindowAdaptor from './adaptors/window';
+import EditableDiffSessionManager from './editable-diff-session-manager';
 
 export default class DiffPresenter {
     private readonly diffTitleBuilder: DiffTitleBuilder;
 
-    constructor(selectionInfoRegistry: SelectionInfoRegistry,
+    constructor(private readonly selectionInfoRegistry: SelectionInfoRegistry,
                 normalisationRuleStore: NormalisationRuleStore,
+                private readonly workspaceAdaptor: WorkspaceAdaptor,
                 private readonly commandAdaptor: CommandAdaptor,
+                private readonly windowAdaptor: WindowAdaptor,
+                private readonly editableDiffSessionManager: EditableDiffSessionManager,
                 private readonly getCurrentDate: () => Date) {
-        this.getCurrentDate = getCurrentDate;
         this.diffTitleBuilder = new DiffTitleBuilder(normalisationRuleStore, selectionInfoRegistry);
-        this.commandAdaptor = commandAdaptor;
     }
 
-    takeDiff(textKey1: string, textKey2: string): Promise<{} | undefined> {
+    async takeDiff(textKey1: string, textKey2: string): Promise<{} | undefined | void> {
+        const editableDiffsEnabled = this.workspaceAdaptor.get<boolean>('enableEditableDiffs');
+        if (editableDiffsEnabled) {
+            const left = this.selectionInfoRegistry.get(textKey1);
+            const right = this.selectionInfoRegistry.get(textKey2);
+            if (left.lineRanges.length > 1 || right.lineRanges.length > 1) {
+                await this.windowAdaptor.showInformationMessage(
+                    'Editable mode does not support multi-selection compare. Falling back to read-only diff.'
+                );
+            } else {
+                const title = this.diffTitleBuilder.build(textKey1, textKey2, false);
+                await this.editableDiffSessionManager.openDiff(textKey1, textKey2, title);
+                return;
+            }
+        }
         const getUri = (textKey: string) => makeUriString(textKey, this.getCurrentDate());
         const title = this.diffTitleBuilder.build(textKey1, textKey2);
         return this.commandAdaptor.executeCommand('vscode.diff', getUri(textKey1), getUri(textKey2), title);

--- a/src/lib/diff-presenter.ts
+++ b/src/lib/diff-presenter.ts
@@ -31,8 +31,14 @@ export default class DiffPresenter {
                 );
             } else {
                 const title = this.diffTitleBuilder.build(textKey1, textKey2, false);
-                await this.editableDiffSessionManager.openDiff(textKey1, textKey2, title);
-                return;
+                try {
+                    await this.editableDiffSessionManager.openDiff(textKey1, textKey2, title);
+                    return;
+                } catch (error) {
+                    // The editable diff relies on an internal workbench command; if it
+                    // changes or disappears, degrade to the read-only diff silently.
+                    console.warn('Failed to open an editable diff. Falling back to read-only diff.', error);
+                }
             }
         }
         const getUri = (textKey: string) => makeUriString(textKey, this.getCurrentDate());

--- a/src/lib/diff-title-builder.ts
+++ b/src/lib/diff-title-builder.ts
@@ -15,10 +15,10 @@ export default class DiffTitleBuilder {
         this.textTitleBuilder = new TextTitleBuilder();
     }
 
-    build(textKey1: string, textKey2: string): string {
+    build(textKey1: string, textKey2: string, useNormalisedSymbol = true): string {
         const title1 = this.buildTextTitle(textKey1);
         const title2 = this.buildTextTitle(textKey2);
-        const comparisonSymbol = this.normalisationRuleStore.hasActiveRules
+        const comparisonSymbol = useNormalisedSymbol && this.normalisationRuleStore.hasActiveRules
             ? DiffModeSymbols.NORMALISED
             : DiffModeSymbols.AS_IS;
         return `${title1} ${comparisonSymbol} ${title2}`;

--- a/src/lib/editable-diff-file-system-provider.ts
+++ b/src/lib/editable-diff-file-system-provider.ts
@@ -1,0 +1,233 @@
+import * as vscode from 'vscode';
+
+interface FileEntry {
+    content: Uint8Array;
+    mtime: number;
+    ctime: number;
+    readOnly: boolean;
+}
+
+/**
+ * Writable in-memory filesystem for editable diff sessions.
+ * Both diff sides are backed by writable resources so that the diff
+ * editor allows in-place edits, which are then applied back to the
+ * source documents by ApplyBackService.
+ */
+export default class EditableDiffFileSystemProvider implements vscode.FileSystemProvider {
+    private readonly files = new Map<string, FileEntry>();
+    private readonly directories = new Set<string>(['/']);
+    private readonly changeEmitter = new vscode.EventEmitter<vscode.FileChangeEvent[]>();
+    readonly onDidChangeFile = this.changeEmitter.event;
+
+    stat(uri: vscode.Uri): vscode.FileStat {
+        const path = this.normalisePath(uri);
+        const file = this.files.get(path);
+        if (file) {
+            return {
+                type: vscode.FileType.File,
+                ctime: file.ctime,
+                mtime: file.mtime,
+                size: file.content.byteLength
+            };
+        }
+        if (this.directories.has(path)) {
+            return {
+                type: vscode.FileType.Directory,
+                ctime: 0,
+                mtime: 0,
+                size: 0
+            };
+        }
+        throw vscode.FileSystemError.FileNotFound(uri);
+    }
+
+    readDirectory(uri: vscode.Uri): [string, vscode.FileType][] {
+        const dirPath = this.normalisePath(uri);
+        if (!this.directories.has(dirPath)) {
+            throw vscode.FileSystemError.FileNotFound(uri);
+        }
+        const childEntries = new Map<string, vscode.FileType>();
+        const dirPrefix = dirPath === '/' ? '/' : `${dirPath}/`;
+
+        this.directories.forEach(path => {
+            if (path === dirPath || !path.startsWith(dirPrefix)) {
+                return;
+            }
+            const rest = path.slice(dirPrefix.length);
+            if (rest.length === 0 || rest.includes('/')) {
+                return;
+            }
+            childEntries.set(rest, vscode.FileType.Directory);
+        });
+
+        this.files.forEach((_file, path) => {
+            if (!path.startsWith(dirPrefix)) {
+                return;
+            }
+            const rest = path.slice(dirPrefix.length);
+            if (rest.length === 0 || rest.includes('/')) {
+                return;
+            }
+            childEntries.set(rest, vscode.FileType.File);
+        });
+
+        return [...childEntries.entries()];
+    }
+
+    createDirectory(uri: vscode.Uri): void {
+        const path = this.normalisePath(uri);
+        const segments = path.split('/').filter(segment => segment.length > 0);
+        let current = '';
+        this.directories.add('/');
+        segments.forEach(segment => {
+            current = `${current}/${segment}`;
+            this.directories.add(current);
+        });
+    }
+
+    readFile(uri: vscode.Uri): Uint8Array {
+        const path = this.normalisePath(uri);
+        const file = this.files.get(path);
+        if (!file) {
+            throw vscode.FileSystemError.FileNotFound(uri);
+        }
+        return file.content;
+    }
+
+    writeFile(uri: vscode.Uri, content: Uint8Array, options: {create: boolean; overwrite: boolean}): void {
+        const path = this.normalisePath(uri);
+        const existing = this.files.get(path);
+        if (existing && !options.overwrite) {
+            throw vscode.FileSystemError.FileExists(uri);
+        }
+        if (!existing && !options.create) {
+            throw vscode.FileSystemError.FileNotFound(uri);
+        }
+        if (existing && existing.readOnly) {
+            throw vscode.FileSystemError.NoPermissions(uri);
+        }
+
+        this.ensureParentDirectoryExists(path, uri);
+        const now = Date.now();
+        this.files.set(path, {
+            content,
+            ctime: existing ? existing.ctime : now,
+            mtime: now,
+            readOnly: existing ? existing.readOnly : this.isReadOnlyPath(path)
+        });
+        this.changeEmitter.fire([{
+            type: existing ? vscode.FileChangeType.Changed : vscode.FileChangeType.Created,
+            uri
+        }]);
+    }
+
+    delete(uri: vscode.Uri, options: {recursive: boolean}): void {
+        const path = this.normalisePath(uri);
+        if (this.files.has(path)) {
+            this.files.delete(path);
+            this.changeEmitter.fire([{type: vscode.FileChangeType.Deleted, uri}]);
+            return;
+        }
+        if (this.directories.has(path)) {
+            const hasChildren = this.hasDirectoryChildren(path);
+            if (hasChildren && !options.recursive) {
+                throw vscode.FileSystemError.NoPermissions(`Directory is not empty: ${uri.toString()}`);
+            }
+            this.deleteDirectoryTree(path);
+            this.changeEmitter.fire([{type: vscode.FileChangeType.Deleted, uri}]);
+            return;
+        }
+        throw vscode.FileSystemError.FileNotFound(uri);
+    }
+
+    rename(oldUri: vscode.Uri, newUri: vscode.Uri, options: {overwrite: boolean}): void {
+        const oldPath = this.normalisePath(oldUri);
+        const newPath = this.normalisePath(newUri);
+        const existing = this.files.get(oldPath);
+        if (!existing) {
+            throw vscode.FileSystemError.FileNotFound(oldUri);
+        }
+        if (this.files.has(newPath) && !options.overwrite) {
+            throw vscode.FileSystemError.FileExists(newUri);
+        }
+        this.ensureParentDirectoryExists(newPath, newUri);
+        this.files.set(newPath, {...existing, mtime: Date.now()});
+        this.files.delete(oldPath);
+        this.changeEmitter.fire([
+            {type: vscode.FileChangeType.Deleted, uri: oldUri},
+            {type: vscode.FileChangeType.Created, uri: newUri}
+        ]);
+    }
+
+    watch(_uri: vscode.Uri, _options: {recursive: boolean; excludes: string[]}): vscode.Disposable {
+        return {dispose() {}};
+    }
+
+    private normalisePath(uri: vscode.Uri): string {
+        const path = uri.path;
+        if (!path || path === '/') {
+            return '/';
+        }
+        if (path.endsWith('/')) {
+            return path.slice(0, -1);
+        }
+        return path;
+    }
+
+    private isReadOnlyPath(path: string): boolean {
+        return path.endsWith('-readonly.txt');
+    }
+
+    private ensureParentDirectoryExists(path: string, uri: vscode.Uri): void {
+        const parent = this.parentPath(path);
+        if (!this.directories.has(parent)) {
+            throw vscode.FileSystemError.FileNotFound(uri);
+        }
+    }
+
+    private parentPath(path: string): string {
+        if (path === '/') {
+            return '/';
+        }
+        const idx = path.lastIndexOf('/');
+        if (idx <= 0) {
+            return '/';
+        }
+        return path.slice(0, idx);
+    }
+
+    private hasDirectoryChildren(path: string): boolean {
+        if (path === '/') {
+            return this.files.size > 0 || this.directories.size > 1;
+        }
+        const prefix = `${path}/`;
+        for (const filePath of this.files.keys()) {
+            if (filePath.startsWith(prefix)) {
+                return true;
+            }
+        }
+        for (const dirPath of this.directories.values()) {
+            if (dirPath !== path && dirPath.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private deleteDirectoryTree(path: string): void {
+        const prefix = path === '/' ? '/' : `${path}/`;
+        if (path !== '/') {
+            this.directories.delete(path);
+        }
+        [...this.files.keys()].forEach(filePath => {
+            if (filePath.startsWith(prefix)) {
+                this.files.delete(filePath);
+            }
+        });
+        [...this.directories.values()].forEach(dirPath => {
+            if (dirPath !== '/' && dirPath.startsWith(prefix)) {
+                this.directories.delete(dirPath);
+            }
+        });
+    }
+}

--- a/src/lib/editable-diff-session-manager.ts
+++ b/src/lib/editable-diff-session-manager.ts
@@ -1,0 +1,155 @@
+import * as vscode from 'vscode';
+import SelectionInfoRegistry from './selection-info-registry';
+import WorkspaceAdaptor from './adaptors/workspace';
+import CommandAdaptor from './adaptors/command';
+import {DiffSession, DiffSessionSide} from './types/diff-session';
+import ApplyBackService from './apply-back-service';
+import {EDITABLE_DIFF_SCHEME} from './const';
+
+/**
+ * Opens diffs as editable sessions: each side is materialised into a
+ * writable in-memory temp file so that the diff editor allows editing,
+ * and edits are routed to ApplyBackService which writes them back to
+ * the source document. Temp files are cleaned up when the diff closes.
+ */
+export default class EditableDiffSessionManager {
+    private readonly sessionsByTempUri = new Map<string, DiffSession>();
+    private readonly listeners: vscode.Disposable[];
+    private nextSessionId = 0;
+
+    constructor(private readonly selectionInfoRegistry: SelectionInfoRegistry,
+                private readonly workspaceAdaptor: WorkspaceAdaptor,
+                private readonly commandAdaptor: CommandAdaptor,
+                private readonly applyBackService: ApplyBackService) {
+        this.listeners = [
+            this.workspaceAdaptor.onDidChangeTextDocument(event => this.onDidChangeTextDocument(event)),
+            this.workspaceAdaptor.onDidCloseTextDocument(doc => this.onDidCloseTextDocument(doc))
+        ];
+    }
+
+    dispose(): void {
+        this.listeners.forEach(listener => listener.dispose());
+        const sessionsById = new Map<string, DiffSession>();
+        this.sessionsByTempUri.forEach(session => sessionsById.set(session.id, session));
+        sessionsById.forEach(session => {
+            this.applyBackService.cancelSession(session);
+            void this.deleteTempFile(session.left.tempUri);
+            void this.deleteTempFile(session.right.tempUri);
+        });
+        this.sessionsByTempUri.clear();
+    }
+
+    async openDiff(textKey1: string, textKey2: string, title: string): Promise<void> {
+        const leftInfo = this.selectionInfoRegistry.get(textKey1);
+        const rightInfo = this.selectionInfoRegistry.get(textKey2);
+        const sessionId = String(this.nextSessionId++);
+        const [leftTempUri, rightTempUri] = await Promise.all([
+            this.createTempFile(sessionId, 'left', leftInfo.text, leftInfo.targetKind === 'clipboard'),
+            this.createTempFile(sessionId, 'right', rightInfo.text, rightInfo.targetKind === 'clipboard')
+        ]);
+        const session: DiffSession = {
+            id: sessionId,
+            title,
+            left: {
+                textKey: textKey1,
+                selectionInfo: leftInfo,
+                originalText: leftInfo.text,
+                tempUri: leftTempUri,
+                conflictNotified: false,
+                sourceChangeNotified: false
+            },
+            right: {
+                textKey: textKey2,
+                selectionInfo: rightInfo,
+                originalText: rightInfo.text,
+                tempUri: rightTempUri,
+                conflictNotified: false,
+                sourceChangeNotified: false
+            }
+        };
+        this.sessionsByTempUri.set(leftTempUri.toString(), session);
+        this.sessionsByTempUri.set(rightTempUri.toString(), session);
+        try {
+            await this.commandAdaptor.executeDiffUris(leftTempUri, rightTempUri, title, {
+                originalEditable: leftInfo.targetKind !== 'clipboard'
+            });
+        } catch (error) {
+            this.sessionsByTempUri.delete(leftTempUri.toString());
+            this.sessionsByTempUri.delete(rightTempUri.toString());
+            await Promise.all([this.deleteTempFile(leftTempUri), this.deleteTempFile(rightTempUri)]);
+            throw error;
+        }
+    }
+
+    private onDidChangeTextDocument(event: vscode.TextDocumentChangeEvent): void {
+        const uriString = event.document.uri.toString();
+        const session = this.sessionsByTempUri.get(uriString);
+        if (session) {
+            const side = this.getSideByUri(session, event.document.uri);
+            if (side) {
+                this.applyBackService.scheduleApply(session, side);
+            }
+            return;
+        }
+        this.routeSourceChange(uriString);
+    }
+
+    private routeSourceChange(uriString: string): void {
+        const seenSessionIds = new Set<string>();
+        this.sessionsByTempUri.forEach(session => {
+            if (seenSessionIds.has(session.id)) {
+                return;
+            }
+            seenSessionIds.add(session.id);
+            [session.left, session.right]
+                .filter(side => side.selectionInfo.sourceUri === uriString)
+                .forEach(side => this.applyBackService.scheduleRefresh(session, side));
+        });
+    }
+
+    private onDidCloseTextDocument(document: vscode.TextDocument): void {
+        const session = this.sessionsByTempUri.get(document.uri.toString());
+        if (!session) {
+            return;
+        }
+        this.cleanupSession(session);
+    }
+
+    private cleanupSession(session: DiffSession): void {
+        this.applyBackService.cancelSession(session);
+        this.sessionsByTempUri.delete(session.left.tempUri.toString());
+        this.sessionsByTempUri.delete(session.right.tempUri.toString());
+        void this.deleteTempFile(session.left.tempUri);
+        void this.deleteTempFile(session.right.tempUri);
+    }
+
+    private getSideByUri(session: DiffSession, uri: vscode.Uri): DiffSessionSide | undefined {
+        const key = uri.toString();
+        if (session.left.tempUri.toString() === key) {
+            return session.left;
+        }
+        if (session.right.tempUri.toString() === key) {
+            return session.right;
+        }
+        return undefined;
+    }
+
+    private async createTempFile(sessionId: string,
+                                 side: 'left' | 'right',
+                                 text: string,
+                                 readOnly: boolean): Promise<vscode.Uri> {
+        const readOnlySuffix = readOnly ? '-readonly' : '';
+        const fileName = `session-${sessionId}-${side}-${Date.now()}-${Math.floor(Math.random() * 1000000000)}${readOnlySuffix}.txt`;
+        const uri = vscode.Uri.parse(`${EDITABLE_DIFF_SCHEME}:/${fileName}`);
+        await this.workspaceAdaptor.writeFile(uri, Buffer.from(text, 'utf8'));
+        return uri;
+    }
+
+    private async deleteTempFile(uri: vscode.Uri): Promise<void> {
+        try {
+            await this.workspaceAdaptor.deleteFile(uri);
+        } catch (error) {
+            // Ignore cleanup failures for already-removed files.
+        }
+    }
+}

--- a/src/lib/selection-info-registry.ts
+++ b/src/lib/selection-info-registry.ts
@@ -9,11 +9,21 @@ export default class SelectionInfoRegistry {
     }
 
     set(key: string, textInfo: SelectionInfo): void {
-        this.data[key] = {
+        const normalised: SelectionInfo = {
             text: textInfo.text,
             fileName: textInfo.fileName,
             lineRanges: textInfo.lineRanges || []
         };
+        if (textInfo.sourceUri) {
+            normalised.sourceUri = textInfo.sourceUri;
+        }
+        if (textInfo.targetKind) {
+            normalised.targetKind = textInfo.targetKind;
+        }
+        if (textInfo.selectionRange) {
+            normalised.selectionRange = textInfo.selectionRange;
+        }
+        this.data[key] = normalised;
     }
 
     get(key: string): SelectionInfo {

--- a/src/lib/types/diff-session.ts
+++ b/src/lib/types/diff-session.ts
@@ -1,0 +1,18 @@
+import * as vscode from 'vscode';
+import {SelectionInfo} from './selection-info';
+
+export interface DiffSessionSide {
+    textKey: string;
+    selectionInfo: SelectionInfo;
+    originalText: string;
+    tempUri: vscode.Uri;
+    conflictNotified: boolean;
+    sourceChangeNotified: boolean;
+}
+
+export interface DiffSession {
+    id: string;
+    title: string;
+    left: DiffSessionSide;
+    right: DiffSessionSide;
+}

--- a/src/lib/types/selection-info.ts
+++ b/src/lib/types/selection-info.ts
@@ -1,11 +1,24 @@
 
+
 export interface SelectionInfo {
     text: string;
     fileName: string;
     lineRanges: LineRange[];
+    sourceUri?: string;
+    targetKind?: ApplyTargetKind;
+    selectionRange?: SelectionRange;
 }
 
 export type LineRange = {
     start: number;
     end: number;
 };
+
+export type SelectionRange = {
+    startLine: number;
+    startChar: number;
+    endLine: number;
+    endChar: number;
+};
+
+export type ApplyTargetKind = 'document' | 'selection' | 'clipboard';

--- a/src/test/lib/adaptors/command.test.ts
+++ b/src/test/lib/adaptors/command.test.ts
@@ -1,0 +1,103 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import CommandAdaptor from '../../../lib/adaptors/command';
+
+suite('CommandAdaptor', () => {
+    test('it opens editable diff above with editable-original options', async () => {
+        let capturedArgs: unknown[] | undefined;
+        const commands = {
+            executeCommand: async (...args: unknown[]) => {
+                capturedArgs = args;
+                return undefined;
+            }
+        };
+        const commandAdaptor = new CommandAdaptor(commands as any, vscode.Uri.parse, console);
+
+        await commandAdaptor.executeDiffUris(
+            vscode.Uri.parse('file:///left.txt'),
+            vscode.Uri.parse('file:///right.txt'),
+            'TITLE'
+        );
+
+        assert.ok(capturedArgs);
+        assert.equal(capturedArgs![0], '_workbench.diff');
+        assert.equal((capturedArgs![1] as vscode.Uri).toString(), 'file:///left.txt');
+        assert.equal((capturedArgs![2] as vscode.Uri).toString(), 'file:///right.txt');
+        assert.equal(capturedArgs![3], 'TITLE');
+        assert.deepEqual(capturedArgs![4], [
+            'up',
+            {
+                originalEditable: true,
+                renderSideBySide: true,
+                useInlineViewWhenSpaceIsLimited: false
+            }
+        ]);
+    });
+
+    test('it can disable editing on original side for editable diff', async () => {
+        let capturedArgs: unknown[] | undefined;
+        const commands = {
+            executeCommand: async (...args: unknown[]) => {
+                capturedArgs = args;
+                return undefined;
+            }
+        };
+        const commandAdaptor = new CommandAdaptor(commands as any, vscode.Uri.parse, console);
+
+        await commandAdaptor.executeDiffUris(
+            vscode.Uri.parse('file:///left.txt'),
+            vscode.Uri.parse('file:///right.txt'),
+            'TITLE',
+            {originalEditable: false}
+        );
+
+        assert.ok(capturedArgs);
+        assert.equal(capturedArgs![0], '_workbench.diff');
+        assert.deepEqual(capturedArgs![4], [
+            'up',
+            {
+                originalEditable: false,
+                renderSideBySide: true,
+                useInlineViewWhenSpaceIsLimited: false
+            }
+        ]);
+    });
+
+    test('it falls back to default group when directional placement is not accepted', async () => {
+        const capturedCalls: unknown[][] = [];
+        const commands = {
+            executeCommand: async (...args: unknown[]) => {
+                capturedCalls.push(args);
+                if (capturedCalls.length === 1) {
+                    throw new Error('unsupported preferred group');
+                }
+                return undefined;
+            }
+        };
+        const commandAdaptor = new CommandAdaptor(commands as any, vscode.Uri.parse, console);
+
+        await commandAdaptor.executeDiffUris(
+            vscode.Uri.parse('file:///left.txt'),
+            vscode.Uri.parse('file:///right.txt'),
+            'TITLE'
+        );
+
+        assert.equal(capturedCalls.length, 2);
+        assert.deepEqual(capturedCalls[0][4], [
+            'up',
+            {
+                originalEditable: true,
+                renderSideBySide: true,
+                useInlineViewWhenSpaceIsLimited: false
+            }
+        ]);
+        assert.deepEqual(capturedCalls[1][4], [
+            undefined,
+            {
+                originalEditable: true,
+                renderSideBySide: true,
+                useInlineViewWhenSpaceIsLimited: false
+            }
+        ]);
+    });
+});

--- a/src/test/lib/apply-back-service.test.ts
+++ b/src/test/lib/apply-back-service.test.ts
@@ -1,0 +1,407 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import {any, mockMethods, verify, when} from '../helpers';
+import WorkspaceAdaptor from '../../lib/adaptors/workspace';
+import WindowAdaptor from '../../lib/adaptors/window';
+import ApplyBackService from '../../lib/apply-back-service';
+import {DiffSession} from '../../lib/types/diff-session';
+
+suite('ApplyBackService', () => {
+    function wait(ms: number): Promise<void> {
+        return new Promise(resolve => setTimeout(resolve, ms));
+    }
+
+    function makeUri(raw: string): vscode.Uri {
+        return {toString: () => raw} as unknown as vscode.Uri;
+    }
+
+    function makeTextDoc(uri: vscode.Uri, text: string): vscode.TextDocument {
+        const offsetAt = (pos: vscode.Position) => {
+            const lines = text.split('\n');
+            let offset = 0;
+            for (let i = 0; i < pos.line; i++) {
+                offset += lines[i].length + 1;
+            }
+            return offset + pos.character;
+        };
+        const positionAt = (offset: number) => {
+            const lines = text.split('\n');
+            let remaining = offset;
+            for (let i = 0; i < lines.length; i++) {
+                if (remaining <= lines[i].length) {
+                    return new vscode.Position(i, remaining);
+                }
+                remaining -= lines[i].length + 1;
+            }
+            return new vscode.Position(lines.length - 1, lines[lines.length - 1].length);
+        };
+        return {
+            uri,
+            getText: (range?: vscode.Range) =>
+                range ? text.slice(offsetAt(range.start), offsetAt(range.end)) : text,
+            positionAt,
+            offsetAt
+        } as unknown as vscode.TextDocument;
+    }
+
+    function makeWindowAdaptor(): WindowAdaptor {
+        return mockMethods<WindowAdaptor>(['showWarningMessage', 'setSelectionInVisibleEditor']);
+    }
+
+    function makeSession(tempUri: vscode.Uri, sourceUri: vscode.Uri, originalText: string): DiffSession {
+        return {
+            id: '1',
+            title: 'title',
+            left: {
+                textKey: 'left',
+                tempUri,
+                originalText,
+                conflictNotified: false,
+                sourceChangeNotified: false,
+                selectionInfo: {
+                    text: originalText,
+                    fileName: 'a.ts',
+                    lineRanges: [{start: 0, end: 0}],
+                    sourceUri: sourceUri.toString(),
+                    targetKind: 'selection',
+                    selectionRange: {startLine: 0, startChar: 0, endLine: 0, endChar: 8}
+                }
+            },
+            right: {
+                textKey: 'right',
+                tempUri: makeUri('untitled:right'),
+                originalText: '',
+                conflictNotified: false,
+                sourceChangeNotified: false,
+                selectionInfo: {text: '', fileName: '', lineRanges: [], targetKind: 'clipboard'}
+            }
+        };
+    }
+
+    function makeWorkspaceAdaptor(tempUri: vscode.Uri,
+                                  tempDoc: vscode.TextDocument,
+                                  sourceDoc: vscode.TextDocument): WorkspaceAdaptor {
+        const workspaceAdaptor = mockMethods<WorkspaceAdaptor>(['openTextDocument', 'applyEdit']);
+        when(workspaceAdaptor.openTextDocument(any())).thenDo(
+            (arg: unknown) =>
+                (arg as vscode.Uri).toString() === tempUri.toString() ? tempDoc : sourceDoc
+        );
+        return workspaceAdaptor;
+    }
+
+    test('it applies edited temp text back to a selection target', async () => {
+        let sourceTextAtRange = 'ORIGINAL';
+        const tempUri = makeUri('untitled:left');
+        const sourceUri = makeUri('file:///source');
+        const tempDoc = {
+            uri: tempUri,
+            getText: () => 'UPDATED'
+        } as unknown as vscode.TextDocument;
+        const sourceDoc = {
+            uri: sourceUri,
+            getText: () => sourceTextAtRange,
+            positionAt: (offset: number) => new vscode.Position(0, offset),
+            offsetAt: (pos: vscode.Position) => pos.character
+        } as unknown as vscode.TextDocument;
+        const workspaceAdaptor = makeWorkspaceAdaptor(tempUri, tempDoc, sourceDoc);
+        when(workspaceAdaptor.applyEdit(any())).thenDo(() => {
+            sourceTextAtRange = 'UPDATED';
+            return true;
+        });
+        const service = new ApplyBackService(workspaceAdaptor, makeWindowAdaptor(), 1);
+        const session = makeSession(tempUri, sourceUri, 'ORIGINAL');
+
+        service.scheduleApply(session, session.left);
+        await wait(10);
+
+        assert.equal(session.left.originalText, 'UPDATED');
+    });
+
+    test('it updates selectionRange after successful apply', async () => {
+        const tempUri = makeUri('untitled:left');
+        const sourceUri = makeUri('file:///source');
+        const tempDoc = {
+            uri: tempUri,
+            getText: () => 'LONGER_UPDATED_TEXT'
+        } as unknown as vscode.TextDocument;
+        const sourceDoc = {
+            uri: sourceUri,
+            getText: () => 'ORIGINAL',
+            positionAt: (offset: number) => new vscode.Position(1, offset - 10),
+            offsetAt: (pos: vscode.Position) => pos.line * 10 + pos.character
+        } as unknown as vscode.TextDocument;
+        const workspaceAdaptor = makeWorkspaceAdaptor(tempUri, tempDoc, sourceDoc);
+        when(workspaceAdaptor.applyEdit(any())).thenDo(() => true);
+        const windowAdaptor = makeWindowAdaptor();
+        const service = new ApplyBackService(workspaceAdaptor, windowAdaptor, 1);
+        const session = makeSession(tempUri, sourceUri, 'ORIGINAL');
+        session.left.selectionInfo.selectionRange = {startLine: 1, startChar: 0, endLine: 1, endChar: 8};
+
+        service.scheduleApply(session, session.left);
+        await wait(10);
+
+        const range = session.left.selectionInfo.selectionRange!;
+        assert.equal(range.startLine, 1);
+        assert.equal(range.startChar, 0);
+        assert.equal(range.endLine, 1);
+        assert.equal(range.endChar, 19);
+        verify(windowAdaptor.setSelectionInVisibleEditor(sourceUri, {
+            startLine: 1,
+            startChar: 0,
+            endLine: 1,
+            endChar: 19
+        }));
+    });
+
+    test('it blocks apply and warns once when source changed', async () => {
+        const tempUri = makeUri('untitled:left');
+        const sourceUri = makeUri('file:///source');
+        const tempDoc = {uri: tempUri, getText: () => 'UPDATED'} as unknown as vscode.TextDocument;
+        const sourceDoc = {
+            uri: sourceUri,
+            getText: () => 'DIFFERENT',
+            positionAt: () => new vscode.Position(0, 0)
+        } as unknown as vscode.TextDocument;
+        const workspaceAdaptor = makeWorkspaceAdaptor(tempUri, tempDoc, sourceDoc);
+        const windowAdaptor = makeWindowAdaptor();
+        const service = new ApplyBackService(workspaceAdaptor, windowAdaptor, 1);
+        const session = makeSession(tempUri, sourceUri, 'ORIGINAL');
+
+        service.scheduleApply(session, session.left);
+        await wait(10);
+        service.scheduleApply(session, session.left);
+        await wait(10);
+
+        assert.equal(session.left.originalText, 'ORIGINAL');
+        verify(windowAdaptor.showWarningMessage('Apply-back blocked: source changed since diff opened.', 'Force Apply'));
+        verify(workspaceAdaptor.applyEdit(any()), {times: 0});
+    });
+
+    test('it force-applies when user chooses Force Apply', async () => {
+        let sourceTextAtRange = 'DIFFERENT';
+        const tempUri = makeUri('untitled:left');
+        const sourceUri = makeUri('file:///source');
+        const tempDoc = {uri: tempUri, getText: () => 'UPDATED'} as unknown as vscode.TextDocument;
+        const sourceDoc = {
+            uri: sourceUri,
+            getText: () => sourceTextAtRange,
+            positionAt: (offset: number) => new vscode.Position(0, offset),
+            offsetAt: (pos: vscode.Position) => pos.character
+        } as unknown as vscode.TextDocument;
+        const workspaceAdaptor = makeWorkspaceAdaptor(tempUri, tempDoc, sourceDoc);
+        let applyEditCallCount = 0;
+        (workspaceAdaptor.applyEdit as unknown as (edit: vscode.WorkspaceEdit) => Promise<boolean>) = async () => {
+            applyEditCallCount += 1;
+            sourceTextAtRange = 'UPDATED';
+            return true;
+        };
+        const windowAdaptor = makeWindowAdaptor();
+        when(windowAdaptor.showWarningMessage(any(), any())).thenDo(() => 'Force Apply');
+        const service = new ApplyBackService(workspaceAdaptor, windowAdaptor, 1);
+        const session = makeSession(tempUri, sourceUri, 'ORIGINAL');
+
+        service.scheduleApply(session, session.left);
+        await wait(10);
+
+        assert.equal(session.left.originalText, 'UPDATED');
+        assert.equal(applyEditCallCount, 1);
+    });
+
+    test('it skips apply-back for clipboard sides', async () => {
+        const tempUri = makeUri('untitled:left');
+        const sourceUri = makeUri('file:///source');
+        const tempDoc = {uri: tempUri, getText: () => 'UPDATED'} as unknown as vscode.TextDocument;
+        const sourceDoc = {
+            uri: sourceUri,
+            getText: () => 'ORIGINAL'
+        } as unknown as vscode.TextDocument;
+        const workspaceAdaptor = makeWorkspaceAdaptor(tempUri, tempDoc, sourceDoc);
+        const service = new ApplyBackService(workspaceAdaptor, makeWindowAdaptor(), 1);
+        const session = makeSession(tempUri, sourceUri, 'ORIGINAL');
+
+        service.scheduleApply(session, session.right);
+        await wait(10);
+
+        verify(workspaceAdaptor.openTextDocument(any()), {times: 0});
+    });
+
+    test('it catches apply-back errors from debounce callback', async () => {
+        const workspaceAdaptor = mockMethods<WorkspaceAdaptor>(['openTextDocument', 'applyEdit']);
+        when(workspaceAdaptor.openTextDocument(any())).thenDo(() => {
+            throw new Error('open failed');
+        });
+        const service = new ApplyBackService(workspaceAdaptor, makeWindowAdaptor(), 1);
+        const session = makeSession(makeUri('untitled:left'), makeUri('file:///source'), 'ORIGINAL');
+
+        const originalConsoleError = console.error;
+        const loggedErrors: unknown[][] = [];
+        console.error = (...args: unknown[]) => {
+            loggedErrors.push(args);
+        };
+        try {
+            service.scheduleApply(session, session.left);
+            await wait(10);
+        } finally {
+            console.error = originalConsoleError;
+        }
+
+        assert.equal(loggedErrors.length, 1);
+        assert.equal(loggedErrors[0][0], 'Failed to apply editable diff changes back to source document.');
+    });
+
+    test('it skips the write when diff side and source are already in sync', async () => {
+        const tempUri = makeUri('untitled:left');
+        const sourceUri = makeUri('file:///source');
+        const tempDoc = makeTextDoc(tempUri, 'SAME');
+        const sourceDoc = makeTextDoc(sourceUri, 'SAME');
+        const workspaceAdaptor = makeWorkspaceAdaptor(tempUri, tempDoc, sourceDoc);
+        const service = new ApplyBackService(workspaceAdaptor, makeWindowAdaptor(), 1);
+        const session = makeSession(tempUri, sourceUri, 'ORIGINAL');
+
+        service.scheduleApply(session, session.left);
+        await wait(10);
+
+        assert.equal(session.left.originalText, 'SAME');
+        verify(workspaceAdaptor.applyEdit(any()), {times: 0});
+    });
+
+    suite('source-to-diff refresh', () => {
+        function makeRefreshWorkspaceAdaptor(tempUri: vscode.Uri,
+                                             tempDoc: vscode.TextDocument,
+                                             sourceDoc: vscode.TextDocument,
+                                             written: {uri: vscode.Uri; content: string}[]): WorkspaceAdaptor {
+            const workspaceAdaptor = mockMethods<WorkspaceAdaptor>(['openTextDocument', 'applyEdit', 'writeFile']);
+            when(workspaceAdaptor.openTextDocument(any())).thenDo(
+                (arg: unknown) =>
+                    (arg as vscode.Uri).toString() === tempUri.toString() ? tempDoc : sourceDoc
+            );
+            (workspaceAdaptor.writeFile as unknown as (uri: vscode.Uri, content: Uint8Array) => Promise<void>) =
+                async (uri: vscode.Uri, content: Uint8Array) => {
+                    written.push({uri, content: Buffer.from(content).toString('utf8')});
+                };
+            return workspaceAdaptor;
+        }
+
+        function makeDocumentSide(tempUri: vscode.Uri,
+                                  sourceUri: vscode.Uri,
+                                  originalText: string): DiffSession['left'] {
+            return {
+                textKey: 'left',
+                tempUri,
+                originalText,
+                conflictNotified: false,
+                sourceChangeNotified: false,
+                selectionInfo: {
+                    text: originalText,
+                    fileName: 'a.ts',
+                    lineRanges: [],
+                    sourceUri: sourceUri.toString(),
+                    targetKind: 'document'
+                }
+            };
+        }
+
+        test('it refreshes an untouched diff side when the source document changes', async () => {
+            const tempUri = makeUri('untitled:left');
+            const sourceUri = makeUri('file:///source');
+            const written: {uri: vscode.Uri; content: string}[] = [];
+            const workspaceAdaptor = makeRefreshWorkspaceAdaptor(
+                tempUri, makeTextDoc(tempUri, 'ORIGINAL'), makeTextDoc(sourceUri, 'NEW CONTENT'), written
+            );
+            const service = new ApplyBackService(workspaceAdaptor, makeWindowAdaptor(), 1);
+            const session = makeSession(tempUri, sourceUri, 'ORIGINAL');
+            session.left = makeDocumentSide(tempUri, sourceUri, 'ORIGINAL');
+
+            service.scheduleRefresh(session, session.left);
+            await wait(10);
+
+            assert.equal(written.length, 1);
+            assert.equal(written[0].content, 'NEW CONTENT');
+            assert.equal(session.left.originalText, 'NEW CONTENT');
+        });
+
+        test('it does not write when the change came from our own apply-back', async () => {
+            const tempUri = makeUri('untitled:left');
+            const sourceUri = makeUri('file:///source');
+            const written: {uri: vscode.Uri; content: string}[] = [];
+            const workspaceAdaptor = makeRefreshWorkspaceAdaptor(
+                tempUri, makeTextDoc(tempUri, 'SAME'), makeTextDoc(sourceUri, 'SAME'), written
+            );
+            const service = new ApplyBackService(workspaceAdaptor, makeWindowAdaptor(), 1);
+            const session = makeSession(tempUri, sourceUri, 'ORIGINAL');
+            session.left = makeDocumentSide(tempUri, sourceUri, 'ORIGINAL');
+
+            service.scheduleRefresh(session, session.left);
+            await wait(10);
+
+            assert.equal(written.length, 0);
+            assert.equal(session.left.originalText, 'SAME');
+        });
+
+        test('it never clobbers user edits in the diff view', async () => {
+            const tempUri = makeUri('untitled:left');
+            const sourceUri = makeUri('file:///source');
+            const written: {uri: vscode.Uri; content: string}[] = [];
+            const workspaceAdaptor = makeRefreshWorkspaceAdaptor(
+                tempUri, makeTextDoc(tempUri, 'USER_EDIT'), makeTextDoc(sourceUri, 'NEW CONTENT'), written
+            );
+            const service = new ApplyBackService(workspaceAdaptor, makeWindowAdaptor(), 1);
+            const session = makeSession(tempUri, sourceUri, 'ORIGINAL');
+            session.left = makeDocumentSide(tempUri, sourceUri, 'ORIGINAL');
+
+            service.scheduleRefresh(session, session.left);
+            await wait(10);
+
+            assert.equal(written.length, 0);
+            assert.equal(session.left.originalText, 'ORIGINAL');
+        });
+
+        test('it re-anchors the selection range when the selected text only moved', async () => {
+            const tempUri = makeUri('untitled:left');
+            const sourceUri = makeUri('file:///source');
+            const written: {uri: vscode.Uri; content: string}[] = [];
+            const workspaceAdaptor = makeRefreshWorkspaceAdaptor(
+                tempUri,
+                makeTextDoc(tempUri, 'ORIGINAL'),
+                makeTextDoc(sourceUri, 'AAAA\nBBBB\nORIGINAL\nCCCC'),
+                written
+            );
+            const service = new ApplyBackService(workspaceAdaptor, makeWindowAdaptor(), 1);
+            const session = makeSession(tempUri, sourceUri, 'ORIGINAL');
+
+            service.scheduleRefresh(session, session.left);
+            await wait(10);
+
+            assert.equal(written.length, 0);
+            assert.deepEqual(session.left.selectionInfo.selectionRange, {
+                startLine: 2, startChar: 0, endLine: 2, endChar: 8
+            });
+        });
+
+        test('it warns once when the selected text itself changed externally', async () => {
+            const tempUri = makeUri('untitled:left');
+            const sourceUri = makeUri('file:///source');
+            const written: {uri: vscode.Uri; content: string}[] = [];
+            const workspaceAdaptor = makeRefreshWorkspaceAdaptor(
+                tempUri,
+                makeTextDoc(tempUri, 'ORIGINAL'),
+                makeTextDoc(sourceUri, 'CHANGED\nCCCC'),
+                written
+            );
+            const windowAdaptor = makeWindowAdaptor();
+            const service = new ApplyBackService(workspaceAdaptor, windowAdaptor, 1);
+            const session = makeSession(tempUri, sourceUri, 'ORIGINAL');
+
+            service.scheduleRefresh(session, session.left);
+            await wait(10);
+            service.scheduleRefresh(session, session.left);
+            await wait(10);
+
+            assert.equal(written.length, 0);
+            assert.equal(session.left.originalText, 'ORIGINAL');
+            verify(windowAdaptor.showWarningMessage(
+                'Source text changed since diff opened. Close and re-run the compare to refresh the diff.'
+            ));
+        });
+    });
+});

--- a/src/test/lib/commands/compare-selection-with-clipboard.test.ts
+++ b/src/test/lib/commands/compare-selection-with-clipboard.test.ts
@@ -5,6 +5,8 @@ import CommandFactory from '../../../lib/command-factory';
 import WindowAdaptor from '../../../lib/adaptors/window';
 import NormalisationRuleStore from '../../../lib/normalisation-rule-store';
 import CommandAdaptor from '../../../lib/adaptors/command';
+import WorkspaceAdaptor from '../../../lib/adaptors/workspace';
+import EditableDiffSessionManager from '../../../lib/editable-diff-session-manager';
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 
@@ -13,7 +15,9 @@ suite('CompareSelectionWithClipboardCommand', () => {
     const editor = mockType<TextEditor>({
         selectedText: 'SELECTED_TEXT',
         fileName: 'FILE2',
-        selectedLineRanges: [{start: 5, end: 10}]
+        uri: 'file:///2',
+        selectedLineRanges: [{start: 5, end: 10}],
+        singleSelectionRange: {startLine: 5, startChar: 0, endLine: 10, endChar: 1}
     });
     const selectionInfoRegistry = new SelectionInfoRegistry();
 
@@ -24,7 +28,16 @@ suite('CompareSelectionWithClipboardCommand', () => {
         const commandAdaptor = mock(CommandAdaptor);
         const windowAdaptor = mock(WindowAdaptor);
         const normalisationRuleStore = mock(NormalisationRuleStore);
-        const commandFactory = new CommandFactory(selectionInfoRegistry, normalisationRuleStore, commandAdaptor, windowAdaptor, clipboard, () => new Date('2016-06-15T11:43:00Z'));
+        const commandFactory = new CommandFactory(
+            selectionInfoRegistry,
+            normalisationRuleStore,
+            mock(WorkspaceAdaptor),
+            commandAdaptor,
+            windowAdaptor,
+            mock(EditableDiffSessionManager),
+            clipboard,
+            () => new Date('2016-06-15T11:43:00Z')
+        );
 
         const command = commandFactory.createCompareSelectionWithClipboardCommand();
 
@@ -33,12 +46,16 @@ suite('CompareSelectionWithClipboardCommand', () => {
         assert.deepEqual(selectionInfoRegistry.get('clipboard'), {
             text: 'CLIPBOARD_TEXT',
             fileName: 'Clipboard',
-            lineRanges: []
+            lineRanges: [],
+            targetKind: 'clipboard'
         });
         assert.deepEqual(selectionInfoRegistry.get('reg2'), {
             fileName: 'FILE2',
             lineRanges: [{'start': 5, 'end': 10}],
-            text: 'SELECTED_TEXT'
+            text: 'SELECTED_TEXT',
+            sourceUri: 'file:///2',
+            targetKind: 'selection',
+            selectionRange: {startLine: 5, startChar: 0, endLine: 10, endChar: 1}
         });
         verify(commandAdaptor.executeCommand(
             'vscode.diff',

--- a/src/test/lib/commands/compare-selection-with-text1.test.ts
+++ b/src/test/lib/commands/compare-selection-with-text1.test.ts
@@ -5,6 +5,8 @@ import NormalisationRuleStore from '../../../lib/normalisation-rule-store';
 import CommandAdaptor from '../../../lib/adaptors/command';
 import TextEditor from '../../../lib/adaptors/text-editor';
 import WindowAdaptor from '../../../lib/adaptors/window';
+import WorkspaceAdaptor from '../../../lib/adaptors/workspace';
+import EditableDiffSessionManager from '../../../lib/editable-diff-session-manager';
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 
@@ -13,7 +15,9 @@ suite('CompareSelectionWithText1', () => {
     const editor = mockType<TextEditor>({
         selectedText: 'SELECTED_TEXT',
         fileName: 'FILE2',
-        selectedLineRanges: [{start: 5, end: 10}]
+        uri: 'file:///2',
+        selectedLineRanges: [{start: 5, end: 10}],
+        singleSelectionRange: {startLine: 5, startChar: 0, endLine: 10, endChar: 1}
     });
 
     const selectionInfoRegistry = new SelectionInfoRegistry();
@@ -30,7 +34,16 @@ suite('CompareSelectionWithText1', () => {
     test('it saves selected text and takes a diff of 2 texts', async () => {
 
         const commandAdaptor = mock(CommandAdaptor);
-        const commandFactory = new CommandFactory(selectionInfoRegistry, normalisationRuleStore, commandAdaptor, windowAdaptor, clipboard, () => new Date('2016-06-15T11:43:00Z'));
+        const commandFactory = new CommandFactory(
+            selectionInfoRegistry,
+            normalisationRuleStore,
+            mock(WorkspaceAdaptor),
+            commandAdaptor,
+            windowAdaptor,
+            mock(EditableDiffSessionManager),
+            clipboard,
+            () => new Date('2016-06-15T11:43:00Z')
+        );
         const command = commandFactory.createCompareSelectionWithText1Command();
 
         await command.execute(editor);
@@ -38,7 +51,10 @@ suite('CompareSelectionWithText1', () => {
         assert.deepEqual(selectionInfoRegistry.get('reg2'), {
             fileName: 'FILE2',
             lineRanges: [{'start': 5, 'end': 10}],
-            text: 'SELECTED_TEXT'
+            text: 'SELECTED_TEXT',
+            sourceUri: 'file:///2',
+            targetKind: 'selection',
+            selectionRange: {startLine: 5, startChar: 0, endLine: 10, endChar: 1}
         });
         verify(commandAdaptor.executeCommand(
             'vscode.diff',

--- a/src/test/lib/commands/compare-visible-editors.test.ts
+++ b/src/test/lib/commands/compare-visible-editors.test.ts
@@ -5,6 +5,8 @@ import WindowAdaptor from '../../../lib/adaptors/window';
 import CommandFactory from '../../../lib/command-factory';
 import CommandAdaptor from '../../../lib/adaptors/command';
 import NormalisationRuleStore from '../../../lib/normalisation-rule-store';
+import WorkspaceAdaptor from '../../../lib/adaptors/workspace';
+import EditableDiffSessionManager from '../../../lib/editable-diff-session-manager';
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 
@@ -13,13 +15,17 @@ suite('CompareVisibleEditorsCommand', () => {
         viewColumn: 1,
         selectedText: 'SELECTED_TEXT_1',
         fileName: 'FILE1',
-        selectedLineRanges: [{start: 5, end: 10}]
+        uri: 'file:///1',
+        selectedLineRanges: [{start: 5, end: 10}],
+        singleSelectionRange: {startLine: 5, startChar: 0, endLine: 10, endChar: 1}
     });
     const editor2 = mockType<TextEditor>({
         viewColumn: 2,
         selectedText: 'SELECTED_TEXT_2',
         fileName: 'FILE2',
-        selectedLineRanges: [{start: 15, end: 20}]
+        uri: 'file:///2',
+        selectedLineRanges: [{start: 15, end: 20}],
+        singleSelectionRange: {startLine: 15, startChar: 0, endLine: 20, endChar: 1}
     });
 
     test('it compares 2 visible editors', async () => {
@@ -29,12 +35,18 @@ suite('CompareVisibleEditorsCommand', () => {
         assert.deepEqual(deps.selectionInfoRegistry.get('visible1'), {
             text: 'SELECTED_TEXT_1',
             fileName: 'FILE1',
-            lineRanges: [{start: 5, end: 10}]
+            lineRanges: [{start: 5, end: 10}],
+            sourceUri: 'file:///1',
+            targetKind: 'selection',
+            selectionRange: {startLine: 5, startChar: 0, endLine: 10, endChar: 1}
         });
         assert.deepEqual(deps.selectionInfoRegistry.get('visible2'), {
             text: 'SELECTED_TEXT_2',
             fileName: 'FILE2',
-            lineRanges: [{start: 15, end: 20}]
+            lineRanges: [{start: 15, end: 20}],
+            sourceUri: 'file:///2',
+            targetKind: 'selection',
+            selectionRange: {startLine: 15, startChar: 0, endLine: 20, endChar: 1}
         });
         verify(deps.commandAdaptor.executeCommand(
             'vscode.diff',
@@ -51,12 +63,18 @@ suite('CompareVisibleEditorsCommand', () => {
         assert.deepEqual(deps.selectionInfoRegistry.get('visible1'), {
             text: 'SELECTED_TEXT_1',
             fileName: 'FILE1',
-            lineRanges: [{start: 5, end: 10}]
+            lineRanges: [{start: 5, end: 10}],
+            sourceUri: 'file:///1',
+            targetKind: 'selection',
+            selectionRange: {startLine: 5, startChar: 0, endLine: 10, endChar: 1}
         });
         assert.deepEqual(deps.selectionInfoRegistry.get('visible2'), {
             text: 'SELECTED_TEXT_2',
             fileName: 'FILE2',
-            lineRanges: [{start: 15, end: 20}]
+            lineRanges: [{start: 15, end: 20}],
+            sourceUri: 'file:///2',
+            targetKind: 'selection',
+            selectionRange: {startLine: 15, startChar: 0, endLine: 20, endChar: 1}
         });
     });
 
@@ -74,7 +92,9 @@ suite('CompareVisibleEditorsCommand', () => {
             viewColumn: 3,
             selectedText: 'SELECTED_TEXT_3',
             fileName: 'FILE3',
-            selectedLineRanges: [{start: 25, end: 30}]
+            uri: 'file:///3',
+            selectedLineRanges: [{start: 25, end: 30}],
+            singleSelectionRange: {startLine: 25, startChar: 0, endLine: 30, endChar: 1}
         });
         const {command, deps} = createCommand([editor1, editor2, editor3]);
         await command.execute();
@@ -93,8 +113,10 @@ suite('CompareVisibleEditorsCommand', () => {
         const commandFactory = new CommandFactory(
             dependencies.selectionInfoRegistry,
             mock(NormalisationRuleStore),
+            mock(WorkspaceAdaptor),
             dependencies.commandAdaptor,
             dependencies.windowAdaptor,
+            mock(EditableDiffSessionManager),
             mockType<typeof vscode.env.clipboard>(),
             () => new Date('2016-06-15T11:43:00Z')
         );

--- a/src/test/lib/commands/save-text-1.test.ts
+++ b/src/test/lib/commands/save-text-1.test.ts
@@ -20,7 +20,8 @@ suite('SelectText1Command', () => {
         assert.deepEqual(selectionInfoRegistry.get('reg1'), {
             text: 'SELECTED_TEXT',
             fileName: 'FILENAME',
-            lineRanges: 'SELECTED_RANGE'
+            lineRanges: 'SELECTED_RANGE',
+            targetKind: 'selection'
         });
     });
 });

--- a/src/test/lib/commands/toggle-normalisation-rules.test.ts
+++ b/src/test/lib/commands/toggle-normalisation-rules.test.ts
@@ -6,6 +6,7 @@ import CommandFactory from '../../../lib/command-factory';
 import SelectionInfoRegistry from '../../../lib/selection-info-registry';
 import WorkspaceAdaptor from '../../../lib/adaptors/workspace';
 import CommandAdaptor from '../../../lib/adaptors/command';
+import EditableDiffSessionManager from '../../../lib/editable-diff-session-manager';
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 
@@ -46,8 +47,10 @@ suite('ToggleNormalisationRulesCommand', () => {
         const commandFactory = new CommandFactory(
             new SelectionInfoRegistry(),
             normalisationRuleStore,
+            workspace,
             mock(CommandAdaptor),
             windowAdaptor,
+            mock(EditableDiffSessionManager),
             mockType<typeof vscode.env.clipboard>(),
             () => new Date('2016-06-15T11:43:00Z')
         );

--- a/src/test/lib/diff-presenter.test.ts
+++ b/src/test/lib/diff-presenter.test.ts
@@ -1,8 +1,11 @@
 import DiffPresenter from '../../lib/diff-presenter';
-import {mock, verify} from '../helpers';
+import {mock, verify, when} from '../helpers';
 import SelectionInfoRegistry from '../../lib/selection-info-registry';
 import NormalisationRuleStore from '../../lib/normalisation-rule-store';
 import CommandAdaptor from '../../lib/adaptors/command';
+import WorkspaceAdaptor from '../../lib/adaptors/workspace';
+import WindowAdaptor from '../../lib/adaptors/window';
+import EditableDiffSessionManager from '../../lib/editable-diff-session-manager';
 
 suite('DiffPresenter', () => {
     const selectionInfoRegistry = new SelectionInfoRegistry();
@@ -11,11 +14,16 @@ suite('DiffPresenter', () => {
 
     test('it passes URI of 2 texts to compare', async () => {
         const commandAdaptor = mock(CommandAdaptor);
+        const workspaceAdaptor = mock(WorkspaceAdaptor);
+        when(workspaceAdaptor.get('enableEditableDiffs')).thenReturn(false);
 
         const diffPresenter = new DiffPresenter(
             selectionInfoRegistry,
             mock(NormalisationRuleStore),
+            workspaceAdaptor,
             commandAdaptor,
+            mock(WindowAdaptor),
+            mock(EditableDiffSessionManager),
             () => new Date('2016-06-15T11:43:00Z')
         );
 
@@ -25,7 +33,65 @@ suite('DiffPresenter', () => {
             'vscode.diff',
             'partialdiff:text/TEXT1?_ts=1465990980000',
             'partialdiff:text/TEXT2?_ts=1465990980000',
-            'FILE1 \u2194 FILE2'
+            'FILE1 ↔ FILE2'
+        ));
+    });
+
+    test('it opens an editable diff session when editable diffs are enabled', async () => {
+        const commandAdaptor = mock(CommandAdaptor);
+        const workspaceAdaptor = mock(WorkspaceAdaptor);
+        when(workspaceAdaptor.get('enableEditableDiffs')).thenReturn(true);
+        const editableDiffSessionManager = mock(EditableDiffSessionManager);
+
+        const diffPresenter = new DiffPresenter(
+            selectionInfoRegistry,
+            mock(NormalisationRuleStore),
+            workspaceAdaptor,
+            commandAdaptor,
+            mock(WindowAdaptor),
+            editableDiffSessionManager,
+            () => new Date('2016-06-15T11:43:00Z')
+        );
+
+        await diffPresenter.takeDiff('TEXT1', 'TEXT2');
+
+        verify(editableDiffSessionManager.openDiff('TEXT1', 'TEXT2', 'FILE1 ↔ FILE2'));
+    });
+
+    test('it falls back to read-only diff for multi-selection compare', async () => {
+        const multiSelectionRegistry = new SelectionInfoRegistry();
+        multiSelectionRegistry.set('TEXT1', {
+            text: 'SELECTED_TEXT1',
+            fileName: 'FILE1',
+            lineRanges: [{start: 1, end: 2}, {start: 5, end: 6}]
+        });
+        multiSelectionRegistry.set('TEXT2', {text: 'SELECTED_TEXT2', fileName: 'FILE2', lineRanges: []});
+        const commandAdaptor = mock(CommandAdaptor);
+        const workspaceAdaptor = mock(WorkspaceAdaptor);
+        when(workspaceAdaptor.get('enableEditableDiffs')).thenReturn(true);
+        const windowAdaptor = mock(WindowAdaptor);
+        const editableDiffSessionManager = mock(EditableDiffSessionManager);
+
+        const diffPresenter = new DiffPresenter(
+            multiSelectionRegistry,
+            mock(NormalisationRuleStore),
+            workspaceAdaptor,
+            commandAdaptor,
+            windowAdaptor,
+            editableDiffSessionManager,
+            () => new Date('2016-06-15T11:43:00Z')
+        );
+
+        await diffPresenter.takeDiff('TEXT1', 'TEXT2');
+
+        verify(windowAdaptor.showInformationMessage(
+            'Editable mode does not support multi-selection compare. Falling back to read-only diff.'
+        ));
+        verify(commandAdaptor.executeCommand(
+            'vscode.diff',
+            'partialdiff:text/TEXT1?_ts=1465990980000',
+            'partialdiff:text/TEXT2?_ts=1465990980000',
+            'FILE1 (ll.2-3,ll.6-7) ↔ FILE2'
         ));
     });
 });

--- a/src/test/lib/diff-presenter.test.ts
+++ b/src/test/lib/diff-presenter.test.ts
@@ -58,6 +58,34 @@ suite('DiffPresenter', () => {
         verify(editableDiffSessionManager.openDiff('TEXT1', 'TEXT2', 'FILE1 ↔ FILE2'));
     });
 
+    test('it falls back to read-only diff when the editable diff fails to open', async () => {
+        const commandAdaptor = mock(CommandAdaptor);
+        const workspaceAdaptor = mock(WorkspaceAdaptor);
+        when(workspaceAdaptor.get('enableEditableDiffs')).thenReturn(true);
+        const editableDiffSessionManager = mock(EditableDiffSessionManager);
+        when(editableDiffSessionManager.openDiff('TEXT1', 'TEXT2', 'FILE1 ↔ FILE2'))
+            .thenReject(new Error('_workbench.diff not found'));
+
+        const diffPresenter = new DiffPresenter(
+            selectionInfoRegistry,
+            mock(NormalisationRuleStore),
+            workspaceAdaptor,
+            commandAdaptor,
+            mock(WindowAdaptor),
+            editableDiffSessionManager,
+            () => new Date('2016-06-15T11:43:00Z')
+        );
+
+        await diffPresenter.takeDiff('TEXT1', 'TEXT2');
+
+        verify(commandAdaptor.executeCommand(
+            'vscode.diff',
+            'partialdiff:text/TEXT1?_ts=1465990980000',
+            'partialdiff:text/TEXT2?_ts=1465990980000',
+            'FILE1 ↔ FILE2'
+        ));
+    });
+
     test('it falls back to read-only diff for multi-selection compare', async () => {
         const multiSelectionRegistry = new SelectionInfoRegistry();
         multiSelectionRegistry.set('TEXT1', {

--- a/src/test/lib/editable-diff-file-system-provider.test.ts
+++ b/src/test/lib/editable-diff-file-system-provider.test.ts
@@ -1,0 +1,42 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import EditableDiffFileSystemProvider from '../../lib/editable-diff-file-system-provider';
+import {EDITABLE_DIFF_SCHEME} from '../../lib/const';
+
+suite('EditableDiffFileSystemProvider', () => {
+    test('it stores and reads writable in-memory files', () => {
+        const provider = new EditableDiffFileSystemProvider();
+        const uri = vscode.Uri.parse(`${EDITABLE_DIFF_SCHEME}:/session-1-left.txt`);
+        const payload = Buffer.from('LEFT', 'utf8');
+
+        provider.writeFile(uri, payload, {create: true, overwrite: true});
+        const stat = provider.stat(uri);
+        const content = provider.readFile(uri);
+
+        assert.equal(stat.type, vscode.FileType.File);
+        assert.equal(Buffer.from(content).toString('utf8'), 'LEFT');
+    });
+
+    test('it deletes files created for a session', () => {
+        const provider = new EditableDiffFileSystemProvider();
+        const uri = vscode.Uri.parse(`${EDITABLE_DIFF_SCHEME}:/session-2-right.txt`);
+
+        provider.writeFile(uri, Buffer.from('RIGHT', 'utf8'), {create: true, overwrite: true});
+        provider.delete(uri, {recursive: false});
+
+        assert.throws(() => provider.stat(uri));
+    });
+
+    test('it enforces read-only temp files', () => {
+        const provider = new EditableDiffFileSystemProvider();
+        const uri = vscode.Uri.parse(`${EDITABLE_DIFF_SCHEME}:/session-3-left-readonly.txt`);
+
+        provider.writeFile(uri, Buffer.from('LEFT', 'utf8'), {create: true, overwrite: true});
+        const stat = provider.stat(uri);
+        assert.equal(stat.type, vscode.FileType.File);
+        assert.throws(() =>
+            provider.writeFile(uri, Buffer.from('UPDATED', 'utf8'), {create: true, overwrite: true})
+        );
+        assert.equal(Buffer.from(provider.readFile(uri)).toString('utf8'), 'LEFT');
+    });
+});

--- a/src/test/lib/editable-diff-session-manager.test.ts
+++ b/src/test/lib/editable-diff-session-manager.test.ts
@@ -1,0 +1,247 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import EditableDiffSessionManager from '../../lib/editable-diff-session-manager';
+import SelectionInfoRegistry from '../../lib/selection-info-registry';
+import WorkspaceAdaptor from '../../lib/adaptors/workspace';
+import CommandAdaptor from '../../lib/adaptors/command';
+import ApplyBackService from '../../lib/apply-back-service';
+import {EDITABLE_DIFF_SCHEME} from '../../lib/const';
+import {any, mockMethods, verify} from '../helpers';
+
+suite('EditableDiffSessionManager', () => {
+    function createSelectionInfoRegistry(): SelectionInfoRegistry {
+        const selectionInfoRegistry = new SelectionInfoRegistry();
+        selectionInfoRegistry.set('left', {text: 'LEFT', fileName: 'a.ts', lineRanges: []});
+        selectionInfoRegistry.set('right', {text: 'RIGHT', fileName: 'b.ts', lineRanges: []});
+        return selectionInfoRegistry;
+    }
+
+    interface Listeners {
+        onChange?: (event: vscode.TextDocumentChangeEvent) => void;
+        onClose?: (doc: vscode.TextDocument) => void;
+    }
+
+    function createWorkspaceAdaptor(writtenUris: vscode.Uri[],
+                                    deletedUris: vscode.Uri[],
+                                    listeners: Listeners = {}): WorkspaceAdaptor {
+        const workspaceAdaptor = mockMethods<WorkspaceAdaptor>([
+            'writeFile',
+            'deleteFile',
+            'openTextDocument',
+            'onDidChangeTextDocument',
+            'onDidCloseTextDocument'
+        ]);
+        (workspaceAdaptor.writeFile as unknown as (uri: vscode.Uri, content: Uint8Array) => Promise<void>) =
+            async (uri: vscode.Uri) => {
+                writtenUris.push(uri);
+            };
+        (workspaceAdaptor.deleteFile as unknown as (uri: vscode.Uri) => Promise<void>) =
+            async (uri: vscode.Uri) => {
+                deletedUris.push(uri);
+            };
+        (workspaceAdaptor.onDidChangeTextDocument as unknown as (listener: (event: vscode.TextDocumentChangeEvent) => void) => vscode.Disposable) =
+            (listener: (event: vscode.TextDocumentChangeEvent) => void) => {
+                listeners.onChange = listener;
+                return {dispose() {}};
+            };
+        (workspaceAdaptor.onDidCloseTextDocument as unknown as (listener: (doc: vscode.TextDocument) => void) => vscode.Disposable) =
+            (listener: (doc: vscode.TextDocument) => void) => {
+                listeners.onClose = listener;
+                return {dispose() {}};
+            };
+        return workspaceAdaptor;
+    }
+
+    function createCommandAdaptor(onExecute?: (...args: unknown[]) => void): CommandAdaptor {
+        const commandAdaptor = mockMethods<CommandAdaptor>(['executeDiffUris']);
+        (commandAdaptor.executeDiffUris as unknown as (...args: unknown[]) => Promise<void>) =
+            async (...args: unknown[]) => {
+                if (onExecute) {
+                    onExecute(...args);
+                }
+            };
+        return commandAdaptor;
+    }
+
+    test('it creates temp files and starts a diff', async () => {
+        const selectionInfoRegistry = createSelectionInfoRegistry();
+        const writtenUris: vscode.Uri[] = [];
+        const deletedUris: vscode.Uri[] = [];
+        const listeners: Listeners = {};
+        const workspaceAdaptor = createWorkspaceAdaptor(writtenUris, deletedUris, listeners);
+        let diffCallCount = 0;
+        const commandAdaptor = createCommandAdaptor(() => {
+            diffCallCount += 1;
+        });
+        const applyBackService = mockMethods<ApplyBackService>(['scheduleApply', 'cancelSession']);
+        const manager = new EditableDiffSessionManager(
+            selectionInfoRegistry,
+            workspaceAdaptor,
+            commandAdaptor,
+            applyBackService
+        );
+
+        await manager.openDiff('left', 'right', 'TITLE');
+
+        assert.equal(writtenUris.length, 2);
+        assert.equal(writtenUris[0].scheme, EDITABLE_DIFF_SCHEME);
+        assert.equal(writtenUris[1].scheme, EDITABLE_DIFF_SCHEME);
+        assert.equal(diffCallCount, 1);
+        assert.ok(listeners.onChange);
+        assert.ok(listeners.onClose);
+        assert.equal(deletedUris.length, 0);
+    });
+
+    test('it disables editing on original side when left side is clipboard', async () => {
+        const selectionInfoRegistry = new SelectionInfoRegistry();
+        selectionInfoRegistry.set('left', {
+            text: 'CLIP',
+            fileName: 'Clipboard',
+            lineRanges: [],
+            targetKind: 'clipboard'
+        });
+        selectionInfoRegistry.set('right', {
+            text: 'RIGHT',
+            fileName: 'a.ts',
+            lineRanges: [{start: 0, end: 0}],
+            sourceUri: 'file:///a.ts',
+            targetKind: 'selection',
+            selectionRange: {startLine: 0, startChar: 0, endLine: 0, endChar: 5}
+        });
+        const writtenUris: vscode.Uri[] = [];
+        const deletedUris: vscode.Uri[] = [];
+        const workspaceAdaptor = createWorkspaceAdaptor(writtenUris, deletedUris);
+
+        let capturedOptions: {originalEditable?: boolean} | undefined;
+        const commandAdaptor = createCommandAdaptor((_left, _right, _title, options) => {
+            capturedOptions = options as {originalEditable?: boolean};
+        });
+        const applyBackService = mockMethods<ApplyBackService>(['scheduleApply', 'cancelSession']);
+        const manager = new EditableDiffSessionManager(
+            selectionInfoRegistry,
+            workspaceAdaptor,
+            commandAdaptor,
+            applyBackService
+        );
+
+        await manager.openDiff('left', 'right', 'TITLE');
+
+        assert.deepEqual(capturedOptions, {originalEditable: false});
+        const uriStrings = writtenUris.map(uri => uri.toString());
+        assert.ok(uriStrings.some(uri => uri.includes('-left-') && uri.includes('-readonly.txt')));
+        assert.ok(uriStrings.some(uri => uri.includes('-right-') && !uri.includes('-readonly.txt')));
+    });
+
+    test('it routes temp document changes to apply-back and cleans up on close', async () => {
+        const selectionInfoRegistry = createSelectionInfoRegistry();
+        const writtenUris: vscode.Uri[] = [];
+        const deletedUris: vscode.Uri[] = [];
+        const listeners: Listeners = {};
+        const workspaceAdaptor = createWorkspaceAdaptor(writtenUris, deletedUris, listeners);
+        const commandAdaptor = createCommandAdaptor();
+        const applyBackService = mockMethods<ApplyBackService>(['scheduleApply', 'cancelSession']);
+        const manager = new EditableDiffSessionManager(
+            selectionInfoRegistry,
+            workspaceAdaptor,
+            commandAdaptor,
+            applyBackService
+        );
+        await manager.openDiff('left', 'right', 'TITLE');
+        const leftDoc = {uri: writtenUris[0]} as vscode.TextDocument;
+
+        listeners.onChange!({document: leftDoc} as vscode.TextDocumentChangeEvent);
+        verify(applyBackService.scheduleApply(any(), any()));
+
+        listeners.onClose!(leftDoc);
+        verify(applyBackService.cancelSession(any()));
+        assert.equal(deletedUris.length, 2);
+    });
+
+    test('it routes source document changes to source-to-diff refresh', async () => {
+        const selectionInfoRegistry = new SelectionInfoRegistry();
+        selectionInfoRegistry.set('left', {
+            text: 'LEFT',
+            fileName: 'a.ts',
+            lineRanges: [],
+            sourceUri: 'file:///a.ts',
+            targetKind: 'document'
+        });
+        selectionInfoRegistry.set('right', {
+            text: 'RIGHT',
+            fileName: 'Clipboard',
+            lineRanges: [],
+            targetKind: 'clipboard'
+        });
+        const writtenUris: vscode.Uri[] = [];
+        const deletedUris: vscode.Uri[] = [];
+        const listeners: Listeners = {};
+        const workspaceAdaptor = createWorkspaceAdaptor(writtenUris, deletedUris, listeners);
+        const commandAdaptor = createCommandAdaptor();
+        const applyBackService = mockMethods<ApplyBackService>(['scheduleApply', 'scheduleRefresh', 'cancelSession']);
+        const manager = new EditableDiffSessionManager(
+            selectionInfoRegistry,
+            workspaceAdaptor,
+            commandAdaptor,
+            applyBackService
+        );
+        await manager.openDiff('left', 'right', 'TITLE');
+
+        listeners.onChange!({document: {uri: {toString: () => 'file:///a.ts'}} as vscode.TextDocument} as vscode.TextDocumentChangeEvent);
+        verify(applyBackService.scheduleRefresh(any(), any()));
+        verify(applyBackService.scheduleApply(any(), any()), {times: 0});
+
+        listeners.onChange!({document: {uri: {toString: () => 'file:///unrelated.ts'}} as vscode.TextDocument} as vscode.TextDocumentChangeEvent);
+        verify(applyBackService.scheduleRefresh(any(), any()), {times: 1});
+    });
+
+    test('it generates unique session IDs in temp file names across rapid opens', async () => {
+        const selectionInfoRegistry = createSelectionInfoRegistry();
+        const writtenUris: vscode.Uri[] = [];
+        const deletedUris: vscode.Uri[] = [];
+        const workspaceAdaptor = createWorkspaceAdaptor(writtenUris, deletedUris);
+        const commandAdaptor = createCommandAdaptor();
+        const applyBackService = mockMethods<ApplyBackService>(['scheduleApply', 'cancelSession']);
+        const manager = new EditableDiffSessionManager(
+            selectionInfoRegistry,
+            workspaceAdaptor,
+            commandAdaptor,
+            applyBackService
+        );
+
+        await manager.openDiff('left', 'right', 'TITLE1');
+        await manager.openDiff('left', 'right', 'TITLE2');
+
+        assert.equal(writtenUris.length, 4);
+        const uriStrings = writtenUris.map(uri => uri.toString());
+        assert.ok(uriStrings.some(uri => uri.includes('session-0-left')));
+        assert.ok(uriStrings.some(uri => uri.includes('session-0-right')));
+        assert.ok(uriStrings.some(uri => uri.includes('session-1-left')));
+        assert.ok(uriStrings.some(uri => uri.includes('session-1-right')));
+    });
+
+    test('it cleans up temp files if diff command fails', async () => {
+        const selectionInfoRegistry = createSelectionInfoRegistry();
+        const writtenUris: vscode.Uri[] = [];
+        const deletedUris: vscode.Uri[] = [];
+        const workspaceAdaptor = createWorkspaceAdaptor(writtenUris, deletedUris);
+        const commandAdaptor = mockMethods<CommandAdaptor>(['executeDiffUris']);
+        (commandAdaptor.executeDiffUris as unknown as () => Promise<void>) =
+            async () => {
+                throw new Error('diff failed');
+            };
+        const applyBackService = mockMethods<ApplyBackService>(['scheduleApply', 'cancelSession']);
+        const manager = new EditableDiffSessionManager(
+            selectionInfoRegistry,
+            workspaceAdaptor,
+            commandAdaptor,
+            applyBackService
+        );
+
+        await assert.rejects(
+            manager.openDiff('left', 'right', 'TITLE'),
+            (err: unknown) => (err as Error).message === 'diff failed'
+        );
+        assert.equal(writtenUris.length, 2);
+        assert.equal(deletedUris.length, 2);
+    });
+});

--- a/src/test/register-vscode-mock.js
+++ b/src/test/register-vscode-mock.js
@@ -1,0 +1,11 @@
+const Module = require('module');
+const path = require('path');
+
+const mockPath = path.join(__dirname, 'vscode-mock.js');
+const origResolveFilename = Module._resolveFilename;
+Module._resolveFilename = function (request, parent, isMain, options) {
+    if (request === 'vscode') {
+        return mockPath;
+    }
+    return origResolveFilename.call(this, request, parent, isMain, options);
+};

--- a/src/test/vscode-mock.js
+++ b/src/test/vscode-mock.js
@@ -1,0 +1,170 @@
+class Position {
+    constructor(line, character) {
+        this.line = line;
+        this.character = character;
+    }
+}
+
+class Range {
+    constructor(startLineOrStart, startCharOrEnd, endLine, endChar) {
+        if (typeof startLineOrStart === 'object') {
+            this.start = startLineOrStart;
+            this.end = startCharOrEnd;
+        } else {
+            this.start = new Position(startLineOrStart, startCharOrEnd);
+            this.end = new Position(endLine, endChar);
+        }
+    }
+}
+
+class Selection {
+    constructor(anchorLineOrAnchor, anchorCharOrActive, activeLine, activeChar) {
+        if (typeof anchorLineOrAnchor === 'object') {
+            this.anchor = anchorLineOrAnchor;
+            this.active = anchorCharOrActive;
+        } else {
+            this.anchor = new Position(anchorLineOrAnchor, anchorCharOrActive);
+            this.active = new Position(activeLine, activeChar);
+        }
+        this.start = this.anchor;
+        this.end = this.active;
+    }
+}
+
+class Uri {
+    constructor(str) {
+        this._str = str;
+        const schemeMatch = /^([a-zA-Z][a-zA-Z0-9+.-]*):/.exec(str);
+        this.scheme = schemeMatch ? schemeMatch[1] : '';
+        if (this.scheme.length > 0) {
+            const afterScheme = str.slice(this.scheme.length + 1);
+            const noQuery = afterScheme.split('?')[0];
+            if (noQuery.startsWith('//')) {
+                const withoutAuthorityPrefix = noQuery.slice(2);
+                const slashIndex = withoutAuthorityPrefix.indexOf('/');
+                if (slashIndex >= 0) {
+                    this.authority = withoutAuthorityPrefix.slice(0, slashIndex);
+                    this.path = withoutAuthorityPrefix.slice(slashIndex);
+                } else {
+                    this.authority = withoutAuthorityPrefix;
+                    this.path = '/';
+                }
+            } else {
+                this.authority = '';
+                this.path = noQuery.startsWith('/') ? noQuery : '/' + noQuery;
+            }
+        } else {
+            this.authority = '';
+            this.path = '';
+        }
+    }
+    static parse(str) {
+        return new Uri(str);
+    }
+    static from(components) {
+        const authority = components.authority || '';
+        const path = components.path || '';
+        const query = components.query ? '?' + components.query : '';
+        const fragment = components.fragment ? '#' + components.fragment : '';
+        if (authority.length > 0) {
+            return new Uri(`${components.scheme}://${authority}${path}${query}${fragment}`);
+        }
+        return new Uri(`${components.scheme}:${path}${query}${fragment}`);
+    }
+    static file(p) {
+        return new Uri('file://' + p);
+    }
+    toString() {
+        return this._str;
+    }
+}
+
+class EventEmitter {
+    constructor() {
+        this._listeners = [];
+        this.event = listener => {
+            this._listeners.push(listener);
+            return {
+                dispose: () => {
+                    this._listeners = this._listeners.filter(l => l !== listener);
+                }
+            };
+        };
+    }
+    fire(value) {
+        this._listeners.slice().forEach(listener => listener(value));
+    }
+    dispose() {
+        this._listeners = [];
+    }
+}
+
+class FileSystemError extends Error {
+    static FileNotFound(resource) {
+        return new FileSystemError(`File not found: ${resource && resource.toString ? resource.toString() : String(resource)}`);
+    }
+    static FileExists(resource) {
+        return new FileSystemError(`File exists: ${resource && resource.toString ? resource.toString() : String(resource)}`);
+    }
+    static NoPermissions(messageOrResource) {
+        return new FileSystemError(
+            typeof messageOrResource === 'string'
+                ? messageOrResource
+                : `No permissions: ${messageOrResource && messageOrResource.toString ? messageOrResource.toString() : String(messageOrResource)}`
+        );
+    }
+}
+
+const FileType = {
+    Unknown: 0,
+    File: 1,
+    Directory: 2,
+    SymbolicLink: 64
+};
+
+const FileChangeType = {
+    Changed: 0,
+    Created: 1,
+    Deleted: 2
+};
+
+const FilePermission = {
+    Readonly: 1,
+    Locked: 2
+};
+
+class WorkspaceEdit {
+    constructor() {
+        this._edits = [];
+    }
+    replace(uri, range, newText) {
+        this._edits.push({uri, range, newText});
+    }
+}
+
+const ViewColumn = {
+    One: 1,
+    Two: 2,
+    Three: 3
+};
+
+const ConfigurationTarget = {
+    Global: 1,
+    Workspace: 2,
+    WorkspaceFolder: 3
+};
+
+module.exports = {
+    Position,
+    Range,
+    Selection,
+    Uri,
+    EventEmitter,
+    WorkspaceEdit,
+    ViewColumn,
+    ConfigurationTarget,
+    FileSystemError,
+    FileType,
+    FileChangeType,
+    FilePermission
+};


### PR DESCRIPTION
Refs #100. Also addresses #30 and #94 (edit the compared text in place, JetBrains-style), #45 (apply differences from one side to the other, git-conflict-resolution-style), and partially #95 (both diff sides are real selectable documents, so copying any chunk out of the diff is trivial).

## Demo

Merging clipboard changes back into the original file by editing the diff view directly:

![Editable diff demo: compare selection with clipboard, edit in the diff view, changes apply back to the source file](https://raw.githubusercontent.com/mymx2/vscode-partial-diff/partial-diff-merge/images/editable-diff-demo.gif)

## What changes

When `partialDiff.enableEditableDiffs` is on (default), comparisons open in an editable diff view instead of a read-only one. Each side is materialised into a writable in-memory temp document (a small custom `FileSystemProvider`), and the diff is opened with `originalEditable` so text can be merged in place.

- Edits made in the diff view are debounce-applied back to the source document. Works for whole-document and single-selection targets; the clipboard side stays read-only.
- If the source document changes while the diff is open, an untouched diff side refreshes from the source. Selection targets are re-anchored when the selected text only moved within the document.
- If both the diff side and the source changed, apply-back is blocked with a Force Apply prompt — nothing is silently overwritten.
- Multi-selection compares fall back to the read-only diff.

## Implementation notes

- The editable diff is opened via the internal `_workbench.diff` command, because the public `vscode.diff` command cannot express `originalEditable`. If that command changes or disappears, the extension silently falls back to the read-only `vscode.diff`, so comparing always works.
- Temp documents live only in memory and are cleaned up when the diff tab closes or the extension deactivates.

## Tests

Unit coverage for the session manager, apply-back service, filesystem provider and command adaptor (a small `vscode` module mock is registered for mocha). Also verified end-to-end on VS Code 1.132: selection apply-back, source-change refresh, and selection re-anchoring after lines shift.